### PR TITLE
SHOPWARE-841: added check to prevent attributes without group ids fro…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- added check to prevent attributes that do not have group ids from being added to products
 
 ## 2.9.70 - 2017-10-25
 ### Changed

--- a/src/Backend/SgateShopgatePlugin/Models/Export/Product/Xml.php
+++ b/src/Backend/SgateShopgatePlugin/Models/Export/Product/Xml.php
@@ -632,6 +632,9 @@ class Shopware_Plugins_Backend_SgateShopgatePlugin_Models_Export_Product_Xml ext
             /* @var $option \Shopware\Models\Article\Configurator\Option */
             foreach ($this->detail->getConfiguratorOptions() as $option) {
                 $group         = $option->getGroup();
+                if (empty($map[$group->getId()])) {
+                    continue;
+                }
                 $itemAttribute = new Shopgate_Model_Catalog_Attribute();
                 $itemAttribute->setGroupUid($map[$group->getId()]);
                 $itemAttribute->setLabel(


### PR DESCRIPTION
I applied the fix Stephan R. wrote after testing in shopware version 4.0.1 and 5.3.0. Worked in both. I couldn't find a case when a legitimate attribute would not have a group id.