### PR TITLE
SHOPWARE-842: modified redirect to use parent product id rather than …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- changed redirect so it is done for the parent product rather than the first variant 
 
 ## 2.9.70 - 2017-10-25
 ### Changed

--- a/src/Backend/SgateShopgatePlugin/Components/Redirect.php
+++ b/src/Backend/SgateShopgatePlugin/Components/Redirect.php
@@ -139,13 +139,9 @@ class Shopware_Plugins_Backend_SgateShopgatePlugin_Components_Redirect
     protected function _getRedirectProductUid($params)
     {
         $query = Shopware()->Db()->query(
-            'SELECT variant.ordernumber
-                  FROM s_articles_details variant
-                     INNER JOIN s_articles product ON product.id = variant.articleID
-                         AND variant.active = 1
-                  WHERE product.id = ?
-                  ORDER BY variant.kind DESC
-                  LIMIT 1',
+            'SELECT ordernumber 
+                  FROM s_articles_details 
+                  WHERE id = ?',
             array($params['sArticle'])
         );
 


### PR DESCRIPTION
…first the variant's

Took Stephan's suggestion in SHOPWARE-842 to pass the product ID of the parent product rather than that of it's first variant. I tested this to ensure it works as expected on both a simple and configurable product (parent with children).

André
I am sorry to stick you with another of my pull requests. If you are too busy for this please let me know and I will seek out another reviewer. 

Thanks
Aaron