### PR TITLE
Change status for batch processed orders

### DIFF
--- a/src/Backend/SgateShopgatePlugin/Bootstrap.php
+++ b/src/Backend/SgateShopgatePlugin/Bootstrap.php
@@ -1009,6 +1009,23 @@ class Shopware_Plugins_Backend_SgateShopgatePlugin_Bootstrap extends Shopware_Co
             case "savePosition":
                 $orderId = $args["subject"]->Request()->getParam("orderId");
                 break;
+            case "batchProcess":
+                $orders = $args["subject"]->Request()->getParam('orders', array(0 => $args["subject"]->Request()->getParams()));
+
+                if (!empty($orders)) {
+                    foreach ($orders as $key => $data) {	
+                        if (empty($data) || empty($data['id'])) {
+			    continue;
+                        }
+                        
+			$orderId = $data['id'];
+                        if ($orderId) {
+                            self::cancelOrder($orderId);
+                            self::confirmOrderShipping($orderId);
+                        }
+                    }
+                }
+		break;
             default:
                 return;
         }


### PR DESCRIPTION
If you change the status of multiple orders with "Batch processing" the status in Shopgate won't change.
This fix enables status sync even if you use "Batch processing".