### PR TITLE
Shopware 851

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - payment surcharges are not exported as shipping costs anymore in case of free shipping
 - default birthday value for Shopware 5.2.0 and higher versions
 - export of adresses in get_customer
+- export of shipping methods in check_cart
 
 ## [2.9.73] - 2017-11-29
 ### Added

--- a/src/Backend/SgateShopgatePlugin/Plugin.php
+++ b/src/Backend/SgateShopgatePlugin/Plugin.php
@@ -3961,7 +3961,7 @@ class ShopgatePluginShopware extends ShopgatePlugin
                     : self::DEFAULT_PAYMENT_METHOD;
         }
 
-        return self::DEFAULT_PAYMENT_METHOD;
+        return 'prepayment';
     }
 
     /**


### PR DESCRIPTION
change default payment method in check_cart to prepayment, which is probably active instead of the shopgate payment method which is never active