### PR TITLE
Shopware 854

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - default birthday value for Shopware 5.2.0 and higher versions
 - export of adresses in get_customer
 - export of shipping methods in check_cart
+- payment mapping for paymorrow
 
 ## [2.9.73] - 2017-11-29
 ### Added

--- a/src/Backend/SgateShopgatePlugin/Plugin.php
+++ b/src/Backend/SgateShopgatePlugin/Plugin.php
@@ -2750,9 +2750,7 @@ class ShopgatePluginShopware extends ShopgatePlugin
 					nationalBankName = ?,
 					nationalBankCode = ?,
 					nationalBankAccountNumber = ?,
-					paymentReference = ?,
-					signature = ?,
-					fullSend = ?
+					paymentReference = ?
 				",
                     array(
                         $order->getNumber(),
@@ -2766,8 +2764,6 @@ class ShopgatePluginShopware extends ShopgatePlugin
                         $infos['national_bank_code'],
                         $infos['national_bank_acc_num'],
                         $infos['request_id'],
-                        '',
-                        (int)1,
                     )
                 );
                 $this->log(


### PR DESCRIPTION
do not set 'signature' and 'fullSend' anymore, since these fields were removed from the database in the paymorrow plugin version 4