### PR TITLE
Shopware 860 amazon pay payment mapping not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- amazon payment mapping
 
 ## [2.9.74] - 2018-01-05
 ### Fixed

--- a/src/Backend/SgateShopgatePlugin/Plugin.php
+++ b/src/Backend/SgateShopgatePlugin/Plugin.php
@@ -3889,7 +3889,7 @@ class ShopgatePluginShopware extends ShopgatePlugin
      * @return string
      */
     protected function getCorrectPaymentNameFromPattern($default, $pattern)
-	{
+    {
         $dql = "SELECT p.name FROM \Shopware\Models\Payment\Payment p WHERE p.name LIKE :namepat";
         $nameResult = Shopware()->Models()->createQuery($dql)
             ->setMaxResults(1)

--- a/src/Backend/SgateShopgatePlugin/Plugin.php
+++ b/src/Backend/SgateShopgatePlugin/Plugin.php
@@ -3882,24 +3882,24 @@ class ShopgatePluginShopware extends ShopgatePlugin
         return $payment;
     }
 
-	/**
-	 * @param string $default
-	 * @param string $pattern
-	 * @return string
-	 */
-	protected function getCorrectPaymentNameFromPattern($default, $pattern) {
-		$dql = "SELECT p.name FROM \Shopware\Models\Payment\Payment p WHERE p.name LIKE :namepat";
-		$nameResult = Shopware()->Models()->createQuery($dql)
-			->setMaxResults(1)
-			->setParameter("namepat", $pattern)
-			->getOneOrNullResult();
+    /**
+     * @param string $default
+     * @param string $pattern
+     *
+     * @return string
+     */
+    protected function getCorrectPaymentNameFromPattern($default, $pattern) {
+        $dql = "SELECT p.name FROM \Shopware\Models\Payment\Payment p WHERE p.name LIKE :namepat";
+        $nameResult = Shopware()->Models()->createQuery($dql)
+            ->setMaxResults(1)
+            ->setParameter("namepat", $pattern)
+            ->getOneOrNullResult();
 
-		if (!empty($nameResult['name'])) {
-			return $nameResult['name'];
-		}
-		return $default;
-
-	}
+        if (!empty($nameResult['name'])) {
+            return $nameResult['name'];
+        }
+        return $default;
+    }
 
     /**
      * @param ShopgateOrder $order

--- a/src/Backend/SgateShopgatePlugin/Plugin.php
+++ b/src/Backend/SgateShopgatePlugin/Plugin.php
@@ -5541,4 +5541,5 @@ class ShopgatePluginShopware extends ShopgatePlugin
     {
         // TODO: Implement syncFavouriteList() method.
     }
+
 }

--- a/src/Backend/SgateShopgatePlugin/Plugin.php
+++ b/src/Backend/SgateShopgatePlugin/Plugin.php
@@ -3888,7 +3888,8 @@ class ShopgatePluginShopware extends ShopgatePlugin
      *
      * @return string
      */
-    protected function getCorrectPaymentNameFromPattern($default, $pattern) {
+    protected function getCorrectPaymentNameFromPattern($default, $pattern)
+	{
         $dql = "SELECT p.name FROM \Shopware\Models\Payment\Payment p WHERE p.name LIKE :namepat";
         $nameResult = Shopware()->Models()->createQuery($dql)
             ->setMaxResults(1)

--- a/src/Backend/SgateShopgatePlugin/Plugin.php
+++ b/src/Backend/SgateShopgatePlugin/Plugin.php
@@ -5541,5 +5541,4 @@ class ShopgatePluginShopware extends ShopgatePlugin
     {
         // TODO: Implement syncFavouriteList() method.
     }
-
 }

--- a/src/Backend/SgateShopgatePlugin/Plugin.php
+++ b/src/Backend/SgateShopgatePlugin/Plugin.php
@@ -3882,6 +3882,25 @@ class ShopgatePluginShopware extends ShopgatePlugin
         return $payment;
     }
 
+	/**
+	 * @param string $default
+	 * @param string $pattern
+	 * @return string
+	 */
+	protected function getCorrectPaymentNameFromPattern($default, $pattern) {
+		$dql = "SELECT p.name FROM \Shopware\Models\Payment\Payment p WHERE p.name LIKE :namepat";
+		$nameResult = Shopware()->Models()->createQuery($dql)
+			->setMaxResults(1)
+			->setParameter("namepat", $pattern)
+			->getOneOrNullResult();
+
+		if (!empty($nameResult['name'])) {
+			return $nameResult['name'];
+		}
+		return $default;
+
+	}
+
     /**
      * @param ShopgateOrder $order
      *

--- a/src/Backend/SgateShopgatePlugin/Plugin.php
+++ b/src/Backend/SgateShopgatePlugin/Plugin.php
@@ -3958,7 +3958,7 @@ class ShopgatePluginShopware extends ShopgatePlugin
             case ShopgateOrder::AMAZON_PAYMENT:
                 return ($this->config->isModuleEnabled('BestitAmazonPaymentsAdvanced')
                     || $this->config->isModuleEnabled('BestitAmazonPay'))
-                    ? "amazon_payments_advanced"
+                    ? $this->getCorrectPaymentNameFromPattern('amazon_payments_advanced', 'amazon_pay%')
                     : self::DEFAULT_PAYMENT_METHOD;
             case ShopgateOrder::SUE:
                 return ($this->config->isModuleEnabled('SofortPayment')


### PR DESCRIPTION
@andre-kraus 
Sorry to stick you with this review. If you aren't able to do it simply let me know and I will seek another reviewer.

The problem here is that for some shops the name of the amazon payments method in the shopware database is 'amazon_payments_advanced' and other use 'amazon_pay.'
I added a method that can query the database with a pattern and get the actual name back.

Thanks
Aaron 