### PR TITLE
Shopware 885 wrong shipping costs because

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - cart rule validation
 - shipping method mapping
 - exporting selected attributes as part of the product description
+- how payment surcharge is deducted from shipping costs
 
 ## [2.9.76] - 2018-01-29
 ### Fixed

--- a/src/Backend/SgateShopgatePlugin/Plugin.php
+++ b/src/Backend/SgateShopgatePlugin/Plugin.php
@@ -4897,6 +4897,8 @@ class ShopgatePluginShopware extends ShopgatePlugin
             )
         );
 
+        Shopware()->System()->_SESSION['sPaymentID'] = $payment->getId();
+
         // let shopware handle the loading of the shipping methods
         $shippingMethods = Shopware()->Modules()->Admin()->sGetPremiumDispatches($countryId, $payment->getId());
 
@@ -4932,8 +4934,8 @@ class ShopgatePluginShopware extends ShopgatePlugin
 
                 $shippingMethods[$key]['shipping_costs'] = $costs['brutto'];
 
-                if ($payment->getSurcharge() <= $costs['surcharge']) {
-                    $shippingMethods[$key]['shipping_costs'] -= $payment->getSurcharge();
+                if ($payment->getSurcharge() > 0 && $shippingMethods[$key]['surchargeCalculation'] !== 3) {
+                    $shippingMethods[$key]['shipping_costs'] -= $costs['surcharge'];
                 }
             }
         }

--- a/src/Backend/SgateShopgatePlugin/Plugin.php
+++ b/src/Backend/SgateShopgatePlugin/Plugin.php
@@ -4930,7 +4930,11 @@ class ShopgatePluginShopware extends ShopgatePlugin
                 );
                 $costs       = Shopware()->Modules()->Admin()->sGetPremiumShippingcosts($countryInfo);
 
-                $shippingMethods[$key]['shipping_costs'] = $costs['brutto'] - $costs['surcharge'];
+                $shippingMethods[$key]['shipping_costs'] = $costs['brutto'];
+
+                if ($payment->getSurcharge() <= $costs['surcharge']) {
+                    $shippingMethods[$key]['shipping_costs'] -= $payment->getSurcharge();
+                }
             }
         }
         Shopware()->Session()->sCountry = $countryId;


### PR DESCRIPTION
Shopware has two types of surcharges that can be added to a shipping cost, payment method surcharge and shipping method surcharge. 

The shopgate plugin works to remove the payment method surcharge from shipping costs because the shopgate system handles that service charge separately. However the method being used took off shipping surcharges in the cases when there was no payment method surcharge.  

This fix addresses this problem while still making sure payment surcharges are removed for the shipping method costs.

It has been tested in Shopware 5 and 3.
