### PR TITLE
SHOPWARE-889: adjustment to export attributes as part of product desc…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## [Unreleased]
 ### Fixed
 - compatibility with the Payone plugin
+- adjustment for exporting attributes as part of the product description when attributes returned with empty elements
 
 ## [2.9.77] - 2018-03-12
 ### Fixed

--- a/src/Backend/SgateShopgatePlugin/Models/Export/Product.php
+++ b/src/Backend/SgateShopgatePlugin/Models/Export/Product.php
@@ -488,7 +488,7 @@ class Shopware_Plugins_Backend_SgateShopgatePlugin_Models_Export_Product extends
      */
     protected function getCustomFieldsAsDescription($description)
     {
-        $attributesAsDescription = $this->config->getExportAttributesAsDescription();
+        $attributesAsDescription = array_filter($this->config->getExportAttributesAsDescription());
         if (empty($attributesAsDescription)) {
             return $description;
         }


### PR DESCRIPTION
…ription to handle when attributes are returned with empty elements

Issue was caused by the way the merchants instance of shopware was returning the export_attributes_as_description configuration. It was being returned as an array with one element which had the value of an empty string. This array did strange things when intersected with the product attributes. The fix here is to simply filter out empty array elements. 

@Menes1337 
I please let me know if you are not able to or don't want to do this review and I will find another reviewer.

Thanks