### PR TITLE
PI-9529 - get_orders: wrong item numbers for simple products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- export right item number for order items
 
 ## [2.9.86] - 2019-04-23
 ### Fixed

--- a/src/Backend/SgateShopgatePlugin/Components/Order.php
+++ b/src/Backend/SgateShopgatePlugin/Components/Order.php
@@ -479,7 +479,7 @@ class Shopware_Plugins_Backend_SgateShopgatePlugin_Components_Order
             if ($detail->getMode() != 2) {
                 /** @var \Shopware\Models\Order\Detail $detail */
                 $shopgateItem = new ShopgateExternalOrderItem();
-                $shopgateItem->setItemNumber($detail->getArticleId() . "-" . $detail->getArticleNumber());
+                $shopgateItem->setItemNumber($detail->getArticleId());
                 $shopgateItem->setItemNumberPublic($detail->getArticleNumber());
                 $shopgateItem->setQuantity((int)$detail->getQuantity());
                 $shopgateItem->setname($detail->getArticleName());


### PR DESCRIPTION
# Pull Request Template

## Description

Adjust item_number for order items

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md