### PR TITLE
Shopware 997 images are not exported for configurable products in shopware 5.6

### DIFF
--- a/src/Backend/SgateShopgatePlugin/Models/Export/Product.php
+++ b/src/Backend/SgateShopgatePlugin/Models/Export/Product.php
@@ -227,8 +227,8 @@ class Shopware_Plugins_Backend_SgateShopgatePlugin_Models_Export_Product extends
                     true
                 );
             }
-            if (!isset($images['src']) || empty($images['src'])) {
-                $images = Shopware()->Modules()->Articles()->sGetArticlePictures($article->getId(), true, 0);
+            if (!isset($images['src']) || !isset($images['src']['0']) || empty($images['src']['0'])) {
+                $images = Shopware()->Modules()->Articles()->sGetArticlePictures($article->getId(), true, 0, $details->getNumber());
             }
 
             // Choose the best available picture in the list (original could also be removed)
@@ -297,7 +297,7 @@ class Shopware_Plugins_Backend_SgateShopgatePlugin_Models_Export_Product extends
                 return $imgSrcArray[self::ORIGINAL];
             }
 
-            if (!file_exists($this->getShopRootFS() . $this->getRelativeImagePath($imgSrcArray[self::ORIGINAL]))) {
+            if (!is_file($this->getShopRootFS() . $this->getRelativeImagePath($imgSrcArray[self::ORIGINAL]))) {
                 $images = array();
                 foreach ($imgSrcArray as $image) {
                     // check for the highest resolution and availablitity of the image
@@ -406,7 +406,7 @@ class Shopware_Plugins_Backend_SgateShopgatePlugin_Models_Export_Product extends
      */
     protected function isWebAddress($address)
     {
-        return preg_match('/^https?:\/\/.*/i', $address) !== false;
+        return preg_match('/^https?:\/\/.*/i', $address) !== 0;
     }
 
     /**


### PR DESCRIPTION
# Pull Request Template

## Description

image export was not working for SHopware 5.6 configurable products

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I updated the CHANGELOG.md
