### PR TITLE
Event Enlight_Controller_Action_Frontend_BonusSystem not working.

### DIFF
--- a/src/Backend/SgateShopgatePlugin/Bootstrap.php
+++ b/src/Backend/SgateShopgatePlugin/Bootstrap.php
@@ -428,7 +428,7 @@ class Shopware_Plugins_Backend_SgateShopgatePlugin_Bootstrap extends Shopware_Co
             );
 
             $this->subscribeEvent(
-              'Enlight_Controller_Action_Frontend_BonusSystem',
+              'Enlight_Controller_Action_Frontend_BonusSystem_Points',
               'onFrontendCustom'
             );
 
@@ -1535,7 +1535,7 @@ class Shopware_Plugins_Backend_SgateShopgatePlugin_Bootstrap extends Shopware_Co
      */
     protected function isInWebView($args)
     {
-        $shopgateAppCookie = $args->getRequest()->getCookie('sgWebView');
+        $shopgateAppCookie = $args->getSubject()->Request()->getCookie('sgWebView');
         $shopgateApp       = Shopware()->Session()->offsetGet('sgWebView');
 
         if ((isset($shopgateApp) && $shopgateApp) || (isset($shopgateAppCookie) && $shopgateAppCookie)) {


### PR DESCRIPTION
additionally $args->getRequest() returns NULL and causes a Exception.

# Pull Request Template

## Description

We use the BonusSystem in one of our Client Shops. We could not get your version to work properly so I tried to figure out what was going wrong. 
I'm not sure why Event Enlight_Controller_Action_Frontend_BonusSystem seems to work for you, but for us, it does not. Only Event Enlight_Controller_Action_Frontend_BonusSystem_Points will properly register the listener.

When the event gets fired I got an Exception in function  isInWebView(). Fixed that too.

## Type of change

- [ x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I updated the CHANGELOG.md
