### PR TITLE
Call updateSession pipeline always when needed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- updateSession pipeline was not called every time when session changed. Caused emtpy cart in engage.
 
 ## [2.9.91] - 2020-07-24
 ### Added

--- a/src/Backend/SgateShopgatePlugin/Bootstrap.php
+++ b/src/Backend/SgateShopgatePlugin/Bootstrap.php
@@ -155,7 +155,7 @@ class Shopware_Plugins_Backend_SgateShopgatePlugin_Bootstrap extends Shopware_Co
      */
     public function getVersion()
     {
-        return '2.9.91';
+        return '2.9.92';
     }
 
     /**
@@ -1403,6 +1403,7 @@ class Shopware_Plugins_Backend_SgateShopgatePlugin_Bootstrap extends Shopware_Co
             $view->assign('sgAccountView', false);
             $view->assign('sgForgotPassword', false);
             $view->assign('sgFrontendAccount', false);
+            $view->assign('sgSessionId', Shopware()->Session()->offsetGet('sessionId'));
         }
     }
 
@@ -1425,6 +1426,7 @@ class Shopware_Plugins_Backend_SgateShopgatePlugin_Bootstrap extends Shopware_Co
         $view->assign('sgFrontendRegister', false);
         $view->assign('sgFrontendAccount', false);
         $view->assign('sgActionName', false);
+        $view->assign('sgSessionId', Shopware()->Session()->offsetGet('sessionId'));
 
         $customCss = Shopware()->Config()->getByNamespace('SgateShopgatePlugin', 'SGATE_CUSTOM_CSS');
         $view->assign('sgCustomCss', $customCss);

--- a/src/Backend/SgateShopgatePlugin/Views/frontend/index/index.tpl
+++ b/src/Backend/SgateShopgatePlugin/Views/frontend/index/index.tpl
@@ -39,7 +39,7 @@
                 .is--act-cart {ldelim}display: none{rdelim}
                 {$sgCustomCss}
             </style>
-            {if $sgActionName === 'confirm' || $sgActionName === 'shippingPayment' ||  $sgActionName === 'cart'}
+            {if $sgSessionId || $sgActionName === 'confirm' || $sgActionName === 'shippingPayment' ||  $sgActionName === 'cart'}
                 <script type="text/javascript">
                     function initPipelineCall () {ldelim}
                         window.SGAppConnector.sendPipelineRequest(

--- a/src/Backend/SgateShopgatePlugin/plugin.xml
+++ b/src/Backend/SgateShopgatePlugin/plugin.xml
@@ -3,13 +3,13 @@
         xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/5.3/engine/Shopware/Components/Plugin/schema/plugin.xsd">
     <label lang="de">Swag Plugin System</label>
     <label lang="en">Swag plugin system</label>
-    <version>2.9.91</version>
+    <version>2.9.92</version>
     <copyright>(c) by Shopgate GmbH</copyright>
     <license>Apache</license>
     <link>https://store.shopware.com/sgate00633f/shopgate-mobile-commerce-fuer-shopware.html</link>
     <author>Shopgate GmbH</author>
     <compatibility minVersion="5.2.0"/>
-    <changelog version="2.9.91">
+    <changelog version="2.9.92">
         <changes lang="en">Added support for bonus points and documents page</changes>
     </changelog>
     <description>


### PR DESCRIPTION
Fix for empty cart after new session (#99)

* CCP-2249 call updateSession pipeline when needed. fix for empty cart after new session

* updated changelog

* CCP-2249 set session id for onFrontendCustom action