### PR TITLE
additional template dir registrations for Shopware 5.3 and higher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- smarty exception: directory not allowed by security setting 
 
 ## [2.9.93]
 ### Fixed

--- a/src/Backend/SgateShopgatePlugin/Bootstrap.php
+++ b/src/Backend/SgateShopgatePlugin/Bootstrap.php
@@ -452,6 +452,18 @@ class Shopware_Plugins_Backend_SgateShopgatePlugin_Bootstrap extends Shopware_Co
                 'onCollectJavascriptFiles'
             );
         }
+
+        if ($config->assertMinimumVersion("5.3.0")) {
+            $this->subscribeEvent(
+                'Enlight_Controller_Action_PreDispatch_Frontend',
+                'registerViewDir'
+            );
+
+            $this->subscribeEvent(
+                'Enlight_Controller_Action_PreDispatch_Widgets',
+                'registerViewDir'
+            );
+        }
     }
 
     /**
@@ -1520,6 +1532,16 @@ class Shopware_Plugins_Backend_SgateShopgatePlugin_Bootstrap extends Shopware_Co
                 $jsDir . 'jquery.shopgate.js',
             )
         );
+    }
+
+    /**
+     * Starting with Shopware 5.3 on default smarty templates can only be loaded from registered template directories.
+     *
+     * @param Enlight_Event_EventArgs $args
+     */
+    public function registerViewDir(\Enlight_Event_EventArgs $args)
+    {
+        $args->getSubject()->View()->addTemplateDir($this->Path() . 'Views/');
     }
 
     /**


### PR DESCRIPTION
# Pull Request Template

## Description

Shopware hat in 5.3 eingeführt, dass smarty (dieser template compiler)  nur noch Templates aus Ordnern bzw Pfaden akzeptiert, die in einem registrierten Ordner liegen.
Im Endeffekt müssen wir also alle templates jedes mal zu einer whitelist hinzufügen, wenn Shopware losrennt (also ein php prozess angestoßen wird)
Wir haben überhaupt erst templates, seit OneDot welche für den web checkout eingeführt hat.
Die lauschen auf ein paar observer, die geworfen werden sollten, wenn entsprechende Frontend Bereiche geöffnet werden.
Nun kann es aber sein, dass eine Seite im Frontend geladen wird, den Observer wirft (unser template also unser template als trustworthy markiert), dann das template lädt und der ganze Kram im cache landet.
Wenn anschließend aus einem widget heraus auf diesen cache Eintrag zugegriffen wird, dann wird auch unser template geladen, wurde in dem Prozess aber nicht als trustworthy markiert und dann wirft smarty diesen Fehler.
Das muss nicht unbedingt was mit einem widget zu tun haben, ist aber am wahrscheinlichsten.
Ich registriere unser template jetzt in einem sehr allgemeinen Observer jeweils im frontend und im widget Bereich und denke, dass wir dann safe sind. So empfiehlt es jedenfalls Shopware

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
