### PR TITLE
apply fix from shop 32227

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- products deleted from cart re-occuring in checkout when SwagAdvancedCart plugin is active
 
 ## [2.9.93]
 ### Fixed

--- a/src/Backend/SgateShopgatePlugin/Components/Cart.php
+++ b/src/Backend/SgateShopgatePlugin/Components/Cart.php
@@ -292,6 +292,10 @@ class Cart
         if (isset($sessionId)) {
             $this->session->offsetSet('sessionId', $sessionId);
             session_id($sessionId);
+            if ($this->isAdvancedCartActive()) {
+                $this->deleteItemFromPermanentBasket($sessionId, $articleId);
+                $this->deleteItemFromCurrentBasket($sessionId, $articleId);
+            }
         }
 
         if (!empty($customerId) && $customerId !== 'null') {
@@ -324,6 +328,95 @@ class Cart
         $httpResponse->setBody(json_encode($response));
         $httpResponse->sendResponse();
         exit();
+    }
+
+    private function isAdvancedCartActive()
+    {
+        try {
+            $pluginManager = Shopware()->Container()->get('shopware_plugininstaller.plugin_manager');
+            $plugin        = $pluginManager->getPluginByName('SwagAdvancedCart');
+
+            return $plugin->getInstalled() && $plugin->getActive();
+        } catch (\Exception $error) {
+            return false;
+        }
+    }
+
+    /**
+     * @param $sessionId
+     * @param $articleId
+     */
+    private function deleteItemFromPermanentBasket($sessionId, $articleId)
+    {
+        $user = Shopware()->Db()->fetchRow('
+                SELECT id FROM s_user
+                WHERE sessionID = ?
+            ', array($sessionId)
+        );
+        if (!isset($user['id'])) {
+            return;
+        }
+        $customerId = $user['id'];
+
+        $basketItem = Shopware()->Db()->fetchRow('
+                SELECT ordernumber FROM s_order_basket
+                WHERE id = ?
+            ', array($articleId)
+        );
+        if (!isset($basketItem['ordernumber'])) {
+            return;
+        }
+        $ordernumber = $basketItem['ordernumber'];
+
+        $permanentBasket = Shopware()->Db()->fetchRow('
+                SELECT id FROM s_order_basket_saved
+                WHERE user_id = ?
+            ', array($customerId)
+        );
+        if (!isset($permanentBasket['id'])) {
+            return;
+        }
+
+        $permanentBasketId = $permanentBasket['id'];
+
+        Shopware()->Db()->query('
+                DELETE FROM s_order_basket_saved_items 
+                WHERE basket_id = ? and article_ordernumber = ?
+            ', array($permanentBasketId, $ordernumber)
+        );
+    }
+
+    /**
+     * @param $sessionId
+     * @param $articleId
+     */
+    private function deleteItemFromCurrentBasket($sessionId, $articleId)
+    {
+        $basketItem = Shopware()->Db()->fetchRow('
+                SELECT ordernumber FROM s_order_basket
+                WHERE id = ?
+            ', array($articleId)
+        );
+        if (!isset($basketItem['ordernumber'])) {
+            return;
+        }
+        $ordernumber = $basketItem['ordernumber'];
+
+        $permanentBasket = Shopware()->Db()->fetchRow('
+                SELECT id FROM s_order_basket_saved
+                WHERE cookie_value = ?
+            ', array($sessionId)
+        );
+        if (!isset($permanentBasket['id'])) {
+            return;
+        }
+        $permanentBasketId = $permanentBasket['id'];
+
+        Shopware()->Db()->query('
+                DELETE FROM s_order_basket_saved_items 
+                WHERE basket_id = ? and article_ordernumber = ?
+            ', array($permanentBasketId, $ordernumber)
+        );
     }
 
     /**

--- a/src/Backend/SgateShopgatePlugin/Components/Cart.php
+++ b/src/Backend/SgateShopgatePlugin/Components/Cart.php
@@ -356,7 +356,6 @@ class Cart
         if (!isset($user['id'])) {
             return;
         }
-        $customerId = $user['id'];
 
         $basketItem = Shopware()->Db()->fetchRow('
                 SELECT ordernumber FROM s_order_basket
@@ -366,24 +365,27 @@ class Cart
         if (!isset($basketItem['ordernumber'])) {
             return;
         }
-        $ordernumber = $basketItem['ordernumber'];
 
-        $permanentBasket = Shopware()->Db()->fetchRow('
+        $permanentBaskets = Shopware()->Db()->fetchAll('
                 SELECT id FROM s_order_basket_saved
                 WHERE user_id = ?
-            ', array($customerId)
+            ', array($user['id'])
         );
-        if (!isset($permanentBasket['id'])) {
+        if (empty($permanentBaskets)) {
             return;
         }
 
-        $permanentBasketId = $permanentBasket['id'];
+        foreach ($permanentBaskets as $permanentBasket) {
+            if (!isset($permanentBasket['id'])) {
+                continue;
+            }
 
-        Shopware()->Db()->query('
+            Shopware()->Db()->query('
                 DELETE FROM s_order_basket_saved_items 
                 WHERE basket_id = ? and article_ordernumber = ?
-            ', array($permanentBasketId, $ordernumber)
-        );
+            ', array($permanentBasket['id'], $basketItem['ordernumber'])
+            );
+        }
     }
 
     /**
@@ -400,7 +402,6 @@ class Cart
         if (!isset($basketItem['ordernumber'])) {
             return;
         }
-        $ordernumber = $basketItem['ordernumber'];
 
         $permanentBasket = Shopware()->Db()->fetchRow('
                 SELECT id FROM s_order_basket_saved
@@ -410,12 +411,11 @@ class Cart
         if (!isset($permanentBasket['id'])) {
             return;
         }
-        $permanentBasketId = $permanentBasket['id'];
 
         Shopware()->Db()->query('
                 DELETE FROM s_order_basket_saved_items 
                 WHERE basket_id = ? and article_ordernumber = ?
-            ', array($permanentBasketId, $ordernumber)
+            ', array($permanentBasket['id'], $basketItem['ordernumber'])
         );
     }
 

--- a/src/Backend/SgateShopgatePlugin/Components/Cart.php
+++ b/src/Backend/SgateShopgatePlugin/Components/Cart.php
@@ -336,6 +336,10 @@ class Cart
             $pluginManager = Shopware()->Container()->get('shopware_plugininstaller.plugin_manager');
             $plugin        = $pluginManager->getPluginByName('SwagAdvancedCart');
 
+            if (empty($plugin)) {
+                return false;
+            }
+
             return $plugin->getInstalled() && $plugin->getActive();
         } catch (\Exception $error) {
             return false;
@@ -403,19 +407,19 @@ class Cart
             return;
         }
 
-        $permanentBasket = Shopware()->Db()->fetchRow('
+        $currentBasket = Shopware()->Db()->fetchRow('
                 SELECT id FROM s_order_basket_saved
                 WHERE cookie_value = ?
             ', array($sessionId)
         );
-        if (!isset($permanentBasket['id'])) {
+        if (!isset($currentBasket['id'])) {
             return;
         }
 
         Shopware()->Db()->query('
                 DELETE FROM s_order_basket_saved_items 
                 WHERE basket_id = ? and article_ordernumber = ?
-            ', array($permanentBasket['id'], $basketItem['ordernumber'])
+            ', array($currentBasket['id'], $basketItem['ordernumber'])
         );
     }
 


### PR DESCRIPTION
# Pull Request Template

## Description

When items are added to the current shopping basket, they are added to the permanent cart, which is handled by the advancedCart plugin. But removing items from the basket, does not remove them from the permanent cart. Those items are merged into the basket again at checkout, creating and endless loop for the customer.
This fix removes items from the permanent cart, when they are removed from the shopping cart in the shopgate app.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
