### PR TITLE
close in app browser, when Paypal checkout is aborted in Shopware 5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- aborting Paypal checkout 
 
 ## [2.9.93]
 ### Fixed

--- a/src/Backend/SgateShopgatePlugin/Views/frontend/_resources/js/jquery.shopgate.js
+++ b/src/Backend/SgateShopgatePlugin/Views/frontend/_resources/js/jquery.shopgate.js
@@ -24,7 +24,7 @@
                     form,
                     urlToken = getUrlParameter('token');
 
-                if (urlToken && urlToken.length > 1) {
+                if (window.location.href.includes('/token/') || (urlToken && urlToken.length > 1)) {
                     var commands = [
                         {
                             'c': 'broadcastEvent',


### PR DESCRIPTION
# Pull Request Template

## Description

Now closing the in-app browser, when Paypal checkout is aborted in Shopware 5.6

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
