### PR TITLE
SG-34 throw custom error when a coupon couldn't be added to an empty …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- error handling when adding a coupon to an empty cart
 
 ## [2.9.96] - 2021-01-11
 ### Fixed

--- a/src/Backend/SgateShopgatePlugin/Components/Cart.php
+++ b/src/Backend/SgateShopgatePlugin/Components/Cart.php
@@ -520,6 +520,11 @@ class Cart
             }
         }
 
+        if ($this->basket->sGetAmount() === array() && !isset($response['addVoucher']['sErrorFlag'])) {
+            $response['addVoucher']['sErrorFlag']        = true;
+            $response['addVoucher']['minimumcharge'] = 0.01;
+        }
+
         $response['promotionVouchers'] = json_encode($promotions);
 
         $httpResponse->setHeader('Content-Type', 'application/json');


### PR DESCRIPTION
…cart

# Pull Request Template

## Description

throw custom error when a coupon couldn't be added to an empty cart. This will be handled in the extension and improve the user experience

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
