### PR TITLE
Sg 39 fix coupon deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Fixed
 - error handling when adding a coupon to an empty cart
 - validation of payment rules for app-user carts
+- coupon removal from app-user carts
 
 ## [2.9.96] - 2021-01-11
 ### Fixed

--- a/src/Backend/SgateShopgatePlugin/Components/Cart.php
+++ b/src/Backend/SgateShopgatePlugin/Components/Cart.php
@@ -332,7 +332,7 @@ class Cart
                 }
             }
         }
-        $response['deleteArticle']     = $this->basket->sDeleteArticle($articleId);
+        $response['deleteArticle']     = $this->basket->sDeleteArticle($voucher ? 'voucher' : $articleId);
         $response['promotionVouchers'] = json_encode($this->session->get('promotionVouchers'));
 
         $httpResponse->setHeader('Content-Type', 'application/json');


### PR DESCRIPTION
# Pull Request Template

## Description

Use core logic for coupon removal from cart instead of articleID. This will allow the user to remove coupons with multiple tax rates (multiple cart items in Shopware logic)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
