### PR TITLE
SG-129 added new session entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Fixed
 - items disappearing from wishlist in some cases
+- web checkout blank pages due to cart items losing `userID` reference
 
 ## [2.9.103] - 2022-03-30
 ### Fixed


### PR DESCRIPTION
## Description

Firstly, on user login this fix calls the "statistics" module that is responsible for cart statistics, but apparently also assigns `userID` to the cart items. This normally happens when any page loads, but first point of contact is the "Account overview" page right after the customer logs in. Since our module does not load any pages after login, it is necessary to call this module manually.

Snippet from `refreshBasket()`:
```php
$userId = (int) $request->getSession()->get('sUserId');
$userAgent = (string) $request->getServer('HTTP_USER_AGENT');
$sql = '
    UPDATE s_order_basket
    SET lastviewport = ?,
        useragent = ?,
        userID = ?
    WHERE sessionID=?
';
```
Secondly, there is also a new session variable introduced that checks the password update date. It's crucial as the `checkUser`  that is called on every page will unset the current customer session if it's not set.

Snippet from  `sAdmin.php`:
```php
$userId = $this->session->offsetGet('sUserId');
$userMail = $this->session->offsetGet('sUserMail');
$passwordChangeDate = $this->session->offsetGet('sUserPasswordChangeDate');

if (empty($userMail)
    || empty($passwordChangeDate)
    || empty($userId)
) {
    $this->session->offsetUnset('sUserMail');
    $this->session->offsetUnset('sUserPasswordChangeDate');
    $this->session->offsetUnset('sUserId');

    return false;
}
```

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
