### PR TITLE
Added support for smarty plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 ### Added
-- Support for custom smarty plugins
+- support for custom smarty plugins
 
 ## [2.9.104] - 2022-05-23
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Support for custom smarty plugins
+
 ## [2.9.104] - 2022-05-23
 ### Added
 - export of regulation price

--- a/src/Backend/SgateShopgatePlugin/Models/Export/Product.php
+++ b/src/Backend/SgateShopgatePlugin/Models/Export/Product.php
@@ -210,7 +210,7 @@ class Shopware_Plugins_Backend_SgateShopgatePlugin_Models_Export_Product extends
     {
         $this->config = $config;
     }
-
+    
     /**
      * @param \Shopware\Models\Article\Detail  $detail
      *
@@ -221,6 +221,9 @@ class Shopware_Plugins_Backend_SgateShopgatePlugin_Models_Export_Product extends
         $template = $this->config->assertMinimumVersion('4.2')
             ? Shopware()->Container()->get('Template')
             : Enlight_Application::Instance()->Bootstrap()->getResource('Template');
+        
+        $pathResolver = Shopware()->Container()->get('theme_path_resolver');
+        $template->addPluginsDir($pathResolver->getSmartyDirectory(Shopware()->Shop()->getTemplate()));
 
         $view           = new Enlight_View_Default($template);
         $sArticle = Shopware()->Modules()->Articles()->sGetProductByOrdernumber($detail->getNumber());

--- a/src/Backend/SgateShopgatePlugin/Models/Export/Product.php
+++ b/src/Backend/SgateShopgatePlugin/Models/Export/Product.php
@@ -210,7 +210,6 @@ class Shopware_Plugins_Backend_SgateShopgatePlugin_Models_Export_Product extends
     {
         $this->config = $config;
     }
-    
     /**
      * @param \Shopware\Models\Article\Detail  $detail
      *


### PR DESCRIPTION
# Pull Request Template

## Description

Custom smarty plugins can now be used, e.g. in the product availability template.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
