### PR TITLE
Bug curb 3160 attribute group uids not unique across export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- attribute group collisions in the Shopgate Omnichannel suite due to exported IDs not being globally (shop-wide) unique
 
 ## [2.9.108] - 2023-04-04
 ### Added

--- a/src/Backend/SgateShopgatePlugin/Bootstrap.php
+++ b/src/Backend/SgateShopgatePlugin/Bootstrap.php
@@ -155,7 +155,7 @@ class Shopware_Plugins_Backend_SgateShopgatePlugin_Bootstrap extends Shopware_Co
      */
     public function getVersion()
     {
-        return '2.9.108';
+        return '2.9.109-alpha.1';
     }
 
     /**

--- a/src/Backend/SgateShopgatePlugin/Models/Export/Product/Xml.php
+++ b/src/Backend/SgateShopgatePlugin/Models/Export/Product/Xml.php
@@ -505,13 +505,12 @@ class Shopware_Plugins_Backend_SgateShopgatePlugin_Models_Export_Product_Xml ext
     public function setAttributeGroups()
     {
         if ($this->hasChildren() && $this->article->getConfiguratorSet()) {
-            $i      = 1;
             $result = array();
 
             /* @var $group Shopware\Models\Article\Configurator\Group */
             foreach ($this->article->getConfiguratorSet()->getGroups() as $group) {
                 $attributeItem = new Shopgate_Model_Catalog_AttributeGroup();
-                $attributeItem->setUid($i);
+                $attributeItem->setUid($group->getId());
                 $attributeItem->setLabel(
                     $this->translationModel->translate(
                         Shopware_Plugins_Backend_SgateShopgatePlugin_Models_Translation::TRANSLATION_KEY_CONFIGURATION_GROUP,
@@ -520,7 +519,6 @@ class Shopware_Plugins_Backend_SgateShopgatePlugin_Models_Export_Product_Xml ext
                     )
                 );
                 $result[] = $attributeItem;
-                $i++;
             }
 
             parent::setAttributeGroups($result);
@@ -636,28 +634,17 @@ class Shopware_Plugins_Backend_SgateShopgatePlugin_Models_Export_Product_Xml ext
         $result = array();
 
         if ($this->article->getConfiguratorSet()) {
-            $map = array();
-            $i   = 1;
-
             if ($this->article->getConfiguratorSet()->getGroups()->isEmpty()) {
                 $this->validChild = false;
 
                 return;
             }
 
-            foreach ($this->article->getConfiguratorSet()->getGroups() as $group) {
-                $map[$group->getId()] = $i;
-                $i++;
-            }
-
             /* @var $option \Shopware\Models\Article\Configurator\Option */
             foreach ($this->detail->getConfiguratorOptions() as $option) {
                 $group         = $option->getGroup();
-                if (empty($map[$group->getId()])) {
-                    continue;
-                }
                 $itemAttribute = new Shopgate_Model_Catalog_Attribute();
-                $itemAttribute->setGroupUid($map[$group->getId()]);
+                $itemAttribute->setGroupUid($group->getId());
                 $itemAttribute->setLabel(
                     $this->translationModel->translate(
                         Shopware_Plugins_Backend_SgateShopgatePlugin_Models_Translation::TRANSLATION_KEY_CONFIGURATION_OPTION,

--- a/src/Backend/SgateShopgatePlugin/plugin.xml
+++ b/src/Backend/SgateShopgatePlugin/plugin.xml
@@ -3,13 +3,13 @@
         xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/5.3/engine/Shopware/Components/Plugin/schema/plugin.xsd">
     <label lang="de">Swag Plugin System</label>
     <label lang="en">Swag plugin system</label>
-    <version>2.9.108</version>
+    <version>2.9.109-alpha.1</version>
     <copyright>(c) by Shopgate GmbH</copyright>
     <license>Apache</license>
     <link>https://store.shopware.com/sgate00633f/shopgate-mobile-commerce-fuer-shopware.html</link>
     <author>Shopgate GmbH</author>
     <compatibility minVersion="5.3.0"/>
-    <changelog version="2.9.108">
+    <changelog version="2.9.109-alpha.1">
         <changes lang="en">
             ### Added
             - support for custom Smarty plugins


### PR DESCRIPTION
# Pull Request Template

## Description

Use the internal ID of attribute groups as UID in the export, rather than incrementing from 1, restarting the count on every new parent product. Otherwise it won't be unique.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
