### PR TITLE
Bug CURB-3214 ignore duplicate attributes on children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+
+## [2.9.109] - 2023-04-11
 ### Fixed
 - attribute group collisions in the Shopgate Omnichannel suite due to exported IDs not being globally (shop-wide) unique
 
@@ -952,7 +954,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/) and this 
 - migrate plugin from Shopware 3.5.x to 4.0.x
 - use doctrine models
 
-[Unreleased]: https://github.com/shopgate/interface-shopware/compare/2.9.108...HEAD
+[Unreleased]: https://github.com/shopgate/interface-shopware/compare/2.9.109...HEAD
+[2.9.109]: https://github.com/shopgate/interface-shopware/compare/2.9.108...2.9.109
 [2.9.108]: https://github.com/shopgate/interface-shopware/compare/2.9.107...2.9.108
 [2.9.107]: https://github.com/shopgate/interface-shopware/compare/2.9.106...2.9.107
 [2.9.106]: https://github.com/shopgate/interface-shopware/compare/2.9.105...2.9.106

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- child products with two options for the same group (e.g. two colors) will now be exported with only the first option;
+  this is likely a case of inconsistent data because products can't be configured like that in the Shopware backend
 
 ## [2.9.109] - 2023-04-11
 ### Fixed

--- a/src/Backend/SgateShopgatePlugin/Bootstrap.php
+++ b/src/Backend/SgateShopgatePlugin/Bootstrap.php
@@ -155,7 +155,7 @@ class Shopware_Plugins_Backend_SgateShopgatePlugin_Bootstrap extends Shopware_Co
      */
     public function getVersion()
     {
-        return '2.9.109';
+        return '2.9.110-alpha.1';
     }
 
     /**

--- a/src/Backend/SgateShopgatePlugin/Bootstrap.php
+++ b/src/Backend/SgateShopgatePlugin/Bootstrap.php
@@ -155,7 +155,7 @@ class Shopware_Plugins_Backend_SgateShopgatePlugin_Bootstrap extends Shopware_Co
      */
     public function getVersion()
     {
-        return '2.9.109-alpha.1';
+        return '2.9.109';
     }
 
     /**

--- a/src/Backend/SgateShopgatePlugin/Models/Export/Product/Xml.php
+++ b/src/Backend/SgateShopgatePlugin/Models/Export/Product/Xml.php
@@ -44,6 +44,9 @@ class Shopware_Plugins_Backend_SgateShopgatePlugin_Models_Export_Product_Xml ext
     /**@var bool */
     public $validChild = true;
 
+    /** @var array<int, bool> */
+    public $assignedAttributeGroups = array();
+
     /**
      * @param Shopware_Plugins_Backend_SgateShopgatePlugin_Components_Export  $exportComponent
      * @param Shopware_Plugins_Backend_SgateShopgatePlugin_Models_Translation $translationModel
@@ -598,6 +601,9 @@ class Shopware_Plugins_Backend_SgateShopgatePlugin_Models_Export_Product_Xml ext
     {
         $children = array();
 
+        // workaround for inconsistent data where one attribute group has multiple values assigned
+        $this->assignedAttributeGroups = [];
+
         if (!$this->getIsChild()) {
             $childProducts = $this->loadChildren();
 
@@ -643,6 +649,14 @@ class Shopware_Plugins_Backend_SgateShopgatePlugin_Models_Export_Product_Xml ext
             /* @var $option \Shopware\Models\Article\Configurator\Option */
             foreach ($this->detail->getConfiguratorOptions() as $option) {
                 $group         = $option->getGroup();
+
+                // workaround for inconsistent data where one attribute group has multiple values assigned
+                if (isset($this->assignedAttributeGroups[$group->getId()])) {
+                    continue;
+                }
+
+                $this->assignedAttributeGroups[$group->getId()] = true;
+
                 $itemAttribute = new Shopgate_Model_Catalog_Attribute();
                 $itemAttribute->setGroupUid($group->getId());
                 $itemAttribute->setLabel(

--- a/src/Backend/SgateShopgatePlugin/plugin.xml
+++ b/src/Backend/SgateShopgatePlugin/plugin.xml
@@ -3,13 +3,13 @@
         xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/5.3/engine/Shopware/Components/Plugin/schema/plugin.xsd">
     <label lang="de">Swag Plugin System</label>
     <label lang="en">Swag plugin system</label>
-    <version>2.9.109</version>
+    <version>2.9.110-alpha.1</version>
     <copyright>(c) by Shopgate GmbH</copyright>
     <license>Apache</license>
     <link>https://store.shopware.com/sgate00633f/shopgate-mobile-commerce-fuer-shopware.html</link>
     <author>Shopgate GmbH</author>
     <compatibility minVersion="5.3.0"/>
-    <changelog version="2.9.109">
+    <changelog version="2.9.110-alpha.1">
         <changes lang="en">
             ### Added
             - support for custom Smarty plugins

--- a/src/Backend/SgateShopgatePlugin/plugin.xml
+++ b/src/Backend/SgateShopgatePlugin/plugin.xml
@@ -3,13 +3,13 @@
         xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/5.3/engine/Shopware/Components/Plugin/schema/plugin.xsd">
     <label lang="de">Swag Plugin System</label>
     <label lang="en">Swag plugin system</label>
-    <version>2.9.109-alpha.1</version>
+    <version>2.9.109</version>
     <copyright>(c) by Shopgate GmbH</copyright>
     <license>Apache</license>
     <link>https://store.shopware.com/sgate00633f/shopgate-mobile-commerce-fuer-shopware.html</link>
     <author>Shopgate GmbH</author>
     <compatibility minVersion="5.3.0"/>
-    <changelog version="2.9.109-alpha.1">
+    <changelog version="2.9.109">
         <changes lang="en">
             ### Added
             - support for custom Smarty plugins


### PR DESCRIPTION
# Pull Request Template

## Description

Fixes the export of products with inconsistent option data. See changelog.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I updated the CHANGELOG.md
