### PR TITLE
SG-177 refactor exit() to fastcgi_finish_request()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased] - 2023-05-11
+### Fixed
+- Remove exit() after sending the response and use fastcgi_finish_request() instead
+
 ## [2.9.110] - 2023-05-05
 ### Fixed
 - child products with two options for the same group (e.g. two colors) will now be exported with only the first option;

--- a/src/Backend/SgateShopgatePlugin/Components/Cart.php
+++ b/src/Backend/SgateShopgatePlugin/Components/Cart.php
@@ -100,7 +100,7 @@ class Cart
                 $httpResponse->setHeader('Content-Type', 'application/json');
                 $httpResponse->setBody('Invalid customer number');
                 $httpResponse->sendResponse();
-                fastcgi_finish_request();
+                $this->webCheckoutHelper->closeRequest();
                 return;
             }
             $customer = $this->webCheckoutHelper->getCustomer($customerId);
@@ -123,7 +123,7 @@ class Cart
             $httpResponse->setHeader('Content-Type', 'application/json');
             $httpResponse->setBody(json_encode($basket));
             $httpResponse->sendResponse();
-            fastcgi_finish_request();
+            $this->webCheckoutHelper->closeRequest();
             return;
         }
 
@@ -179,7 +179,7 @@ class Cart
         $httpResponse->setHeader('Content-Type', 'application/json');
         $httpResponse->setBody(json_encode($basket));
         $httpResponse->sendResponse();
-        fastcgi_finish_request();
+        $this->webCheckoutHelper->closeRequest();
     }
 
     /**
@@ -237,7 +237,7 @@ class Cart
         }
         $httpResponse->setHeader('Content-Type', 'application/json');
         $httpResponse->sendResponse();
-        fastcgi_finish_request();
+        $this->webCheckoutHelper->closeRequest();
     }
 
     /**
@@ -288,7 +288,7 @@ class Cart
         }
 
         $httpResponse->sendResponse();
-        fastcgi_finish_request();
+        $this->webCheckoutHelper->closeRequest();
     }
 
     /**
@@ -348,7 +348,7 @@ class Cart
         $httpResponse->setHeader('Content-Type', 'application/json');
         $httpResponse->setBody(json_encode($response));
         $httpResponse->sendResponse();
-        fastcgi_finish_request();
+        $this->webCheckoutHelper->closeRequest();
     }
 
     /**
@@ -508,7 +508,7 @@ class Cart
 
             $httpResponse->setBody(html_entity_decode(json_encode($response)));
             $httpResponse->sendResponse();
-            fastcgi_finish_request();
+            $this->webCheckoutHelper->closeRequest();
             return;
         }
 
@@ -546,7 +546,7 @@ class Cart
         $httpResponse->setHeader('Content-Type', 'application/json');
         $httpResponse->setBody(html_entity_decode(json_encode($response)));
         $httpResponse->sendResponse();
-        fastcgi_finish_request();
+        $this->webCheckoutHelper->closeRequest();
     }
 
     /**

--- a/src/Backend/SgateShopgatePlugin/Components/Cart.php
+++ b/src/Backend/SgateShopgatePlugin/Components/Cart.php
@@ -100,7 +100,8 @@ class Cart
                 $httpResponse->setHeader('Content-Type', 'application/json');
                 $httpResponse->setBody('Invalid customer number');
                 $httpResponse->sendResponse();
-                exit();
+                fastcgi_finish_request();
+                return;
             }
             $customer = $this->webCheckoutHelper->getCustomer($customerId);
             if ($this->webCheckoutHelper->getConfig()->assertMinimumVersion('5.7.0')) {
@@ -122,7 +123,8 @@ class Cart
             $httpResponse->setHeader('Content-Type', 'application/json');
             $httpResponse->setBody(json_encode($basket));
             $httpResponse->sendResponse();
-            exit();
+            fastcgi_finish_request();
+            return;
         }
 
         $this->session->offsetSet('sBasketQuantity', $this->basket->sCountBasket());
@@ -177,7 +179,7 @@ class Cart
         $httpResponse->setHeader('Content-Type', 'application/json');
         $httpResponse->setBody(json_encode($basket));
         $httpResponse->sendResponse();
-        exit();
+        fastcgi_finish_request();
     }
 
     /**
@@ -235,7 +237,7 @@ class Cart
         }
         $httpResponse->setHeader('Content-Type', 'application/json');
         $httpResponse->sendResponse();
-        exit();
+        fastcgi_finish_request();
     }
 
     /**
@@ -286,7 +288,7 @@ class Cart
         }
 
         $httpResponse->sendResponse();
-        exit();
+        fastcgi_finish_request();
     }
 
     /**
@@ -346,7 +348,7 @@ class Cart
         $httpResponse->setHeader('Content-Type', 'application/json');
         $httpResponse->setBody(json_encode($response));
         $httpResponse->sendResponse();
-        exit();
+        fastcgi_finish_request();
     }
 
     /**
@@ -506,7 +508,8 @@ class Cart
 
             $httpResponse->setBody(html_entity_decode(json_encode($response)));
             $httpResponse->sendResponse();
-            exit();
+            fastcgi_finish_request();
+            return;
         }
 
         $this->basket->sGetBasket();
@@ -543,7 +546,7 @@ class Cart
         $httpResponse->setHeader('Content-Type', 'application/json');
         $httpResponse->setBody(html_entity_decode(json_encode($response)));
         $httpResponse->sendResponse();
-        exit();
+        fastcgi_finish_request();
     }
 
     /**

--- a/src/Backend/SgateShopgatePlugin/Components/User.php
+++ b/src/Backend/SgateShopgatePlugin/Components/User.php
@@ -107,7 +107,8 @@ class User
                 $httpResponse->setHttpResponseCode(401);
                 $httpResponse->setBody(json_encode($user));
                 $httpResponse->sendResponse();
-                exit();
+                fastcgi_finish_request();
+                return;
             } else {
                 $httpResponse->setHttpResponseCode(200);
                 $httpResponse->setBody(
@@ -124,7 +125,8 @@ class User
                     )
                 );
                 $httpResponse->sendResponse();
-                exit();
+                fastcgi_finish_request();
+                return;
             }
         } else {
             $error = $this->admin->sLogin();
@@ -156,7 +158,7 @@ class User
         $this->basket->sRefreshBasket();
 
         $httpResponse->sendResponse();
-        exit();
+        fastcgi_finish_request();
     }
 
     /**

--- a/src/Backend/SgateShopgatePlugin/Components/User.php
+++ b/src/Backend/SgateShopgatePlugin/Components/User.php
@@ -107,7 +107,7 @@ class User
                 $httpResponse->setHttpResponseCode(401);
                 $httpResponse->setBody(json_encode($user));
                 $httpResponse->sendResponse();
-                fastcgi_finish_request();
+                $this->webCheckoutHelper->closeRequest();
                 return;
             } else {
                 $httpResponse->setHttpResponseCode(200);
@@ -125,7 +125,7 @@ class User
                     )
                 );
                 $httpResponse->sendResponse();
-                fastcgi_finish_request();
+                $this->webCheckoutHelper->closeRequest();
                 return;
             }
         } else {
@@ -158,7 +158,7 @@ class User
         $this->basket->sRefreshBasket();
 
         $httpResponse->sendResponse();
-        fastcgi_finish_request();
+        $this->webCheckoutHelper->closeRequest();
     }
 
     /**

--- a/src/Backend/SgateShopgatePlugin/Controllers/Frontend/shopgate.php
+++ b/src/Backend/SgateShopgatePlugin/Controllers/Frontend/shopgate.php
@@ -1,4 +1,4 @@
-<?php
+f<?php
 /**
  * Copyright Shopgate Inc.
  *
@@ -415,7 +415,7 @@ class Shopware_Controllers_Frontend_Shopgate extends Enlight_Controller_Action i
             )
         );
 
-        fastcgi_finish_request();
+        $this->webCheckoutHelper->closeRequest();
     }
 
     /**
@@ -632,7 +632,7 @@ class Shopware_Controllers_Frontend_Shopgate extends Enlight_Controller_Action i
         $this->Response()->setHeader('Content-Type', 'application/json');
         $this->Response()->setBody(json_encode($response));
         $this->Response()->sendResponse();
-        fastcgi_finish_request();
+        $this->webCheckoutHelper->closeRequest();
     }
 
     /**
@@ -645,7 +645,7 @@ class Shopware_Controllers_Frontend_Shopgate extends Enlight_Controller_Action i
         $this->Response()->setHeader('Content-Type', 'application/json');
         $this->Response()->setBody(json_encode($response));
         $this->Response()->sendResponse();
-        fastcgi_finish_request();
+        $this->webCheckoutHelper->closeRequest();
     }
 
     /**
@@ -662,7 +662,8 @@ class Shopware_Controllers_Frontend_Shopgate extends Enlight_Controller_Action i
         $this->Response()->setHeader('Content-Type', 'application/json');
         $this->Response()->setBody(json_encode($response));
         $this->Response()->sendResponse();
-        fastcgi_finish_request();
+        $this->Response()->send();
+        $this->webCheckoutHelper->closeRequest();
     }
 
     /**
@@ -679,7 +680,7 @@ class Shopware_Controllers_Frontend_Shopgate extends Enlight_Controller_Action i
         $this->Response()->setHeader('Content-Type', 'application/json');
         $this->Response()->setBody(json_encode($response));
         $this->Response()->sendResponse();
-        fastcgi_finish_request();
+        $this->webCheckoutHelper->closeRequest();
     }
 
     /**
@@ -734,7 +735,7 @@ class Shopware_Controllers_Frontend_Shopgate extends Enlight_Controller_Action i
         $this->Response()->setHeader('Content-Type', 'application/json');
         $this->Response()->setBody(json_encode($response));
         $this->Response()->sendResponse();
-        fastcgi_finish_request();
+        $this->webCheckoutHelper->closeRequest();
     }
 
     /**
@@ -755,7 +756,7 @@ class Shopware_Controllers_Frontend_Shopgate extends Enlight_Controller_Action i
         $this->Response()->setHeader('Content-Type', 'application/json');
         $this->Response()->setBody(json_encode($response));
         $this->Response()->sendResponse();
-        fastcgi_finish_request();
+        $this->webCheckoutHelper->closeRequest();
     }
 
     /**
@@ -778,6 +779,6 @@ class Shopware_Controllers_Frontend_Shopgate extends Enlight_Controller_Action i
         $this->Response()->setHeader('Content-Type', 'application/json');
         $this->Response()->setBody(json_encode($response));
         $this->Response()->sendResponse();
-        fastcgi_finish_request();
+        $this->webCheckoutHelper->closeRequest();
     }
 }

--- a/src/Backend/SgateShopgatePlugin/Controllers/Frontend/shopgate.php
+++ b/src/Backend/SgateShopgatePlugin/Controllers/Frontend/shopgate.php
@@ -415,7 +415,7 @@ class Shopware_Controllers_Frontend_Shopgate extends Enlight_Controller_Action i
             )
         );
 
-        exit;
+        fastcgi_finish_request();
     }
 
     /**
@@ -632,7 +632,7 @@ class Shopware_Controllers_Frontend_Shopgate extends Enlight_Controller_Action i
         $this->Response()->setHeader('Content-Type', 'application/json');
         $this->Response()->setBody(json_encode($response));
         $this->Response()->sendResponse();
-        exit();
+        fastcgi_finish_request();
     }
 
     /**
@@ -645,7 +645,7 @@ class Shopware_Controllers_Frontend_Shopgate extends Enlight_Controller_Action i
         $this->Response()->setHeader('Content-Type', 'application/json');
         $this->Response()->setBody(json_encode($response));
         $this->Response()->sendResponse();
-        exit();
+        fastcgi_finish_request();
     }
 
     /**
@@ -662,7 +662,7 @@ class Shopware_Controllers_Frontend_Shopgate extends Enlight_Controller_Action i
         $this->Response()->setHeader('Content-Type', 'application/json');
         $this->Response()->setBody(json_encode($response));
         $this->Response()->sendResponse();
-        exit();
+        fastcgi_finish_request();
     }
 
     /**
@@ -679,7 +679,7 @@ class Shopware_Controllers_Frontend_Shopgate extends Enlight_Controller_Action i
         $this->Response()->setHeader('Content-Type', 'application/json');
         $this->Response()->setBody(json_encode($response));
         $this->Response()->sendResponse();
-        exit();
+        fastcgi_finish_request();
     }
 
     /**
@@ -734,7 +734,7 @@ class Shopware_Controllers_Frontend_Shopgate extends Enlight_Controller_Action i
         $this->Response()->setHeader('Content-Type', 'application/json');
         $this->Response()->setBody(json_encode($response));
         $this->Response()->sendResponse();
-        exit();
+        fastcgi_finish_request();
     }
 
     /**
@@ -755,7 +755,7 @@ class Shopware_Controllers_Frontend_Shopgate extends Enlight_Controller_Action i
         $this->Response()->setHeader('Content-Type', 'application/json');
         $this->Response()->setBody(json_encode($response));
         $this->Response()->sendResponse();
-        exit();
+        fastcgi_finish_request();
     }
 
     /**
@@ -778,6 +778,6 @@ class Shopware_Controllers_Frontend_Shopgate extends Enlight_Controller_Action i
         $this->Response()->setHeader('Content-Type', 'application/json');
         $this->Response()->setBody(json_encode($response));
         $this->Response()->sendResponse();
-        exit();
+        fastcgi_finish_request();
     }
 }

--- a/src/Backend/SgateShopgatePlugin/Helpers/WebCheckout.php
+++ b/src/Backend/SgateShopgatePlugin/Helpers/WebCheckout.php
@@ -31,6 +31,7 @@ use Enlight_Exception;
 use Exception;
 use Firebase\JWT\JWT;
 use Firebase\JWT\Key;
+use http\Exception\BadHeaderException;
 use Shopware\Models\Customer\Customer;
 use Shopware_Plugins_Backend_SgateShopgatePlugin_Components_Config;
 use Zend_Db_Adapter_Exception;
@@ -150,7 +151,8 @@ class WebCheckout
         if ($header !== 'application/json') {
             $response->setHttpResponseCode(404);
             $response->sendResponse();
-            exit();
+            fastcgi_finish_request();
+            throw new BadHeaderException('Invalid Content-Type given.');
         }
 
         $content = trim(file_get_contents("php://input"));

--- a/src/Backend/SgateShopgatePlugin/Helpers/WebCheckout.php
+++ b/src/Backend/SgateShopgatePlugin/Helpers/WebCheckout.php
@@ -34,7 +34,9 @@ use Firebase\JWT\Key;
 use http\Exception\BadHeaderException;
 use Shopware\Models\Customer\Customer;
 use Shopware_Plugins_Backend_SgateShopgatePlugin_Components_Config;
+
 use Zend_Db_Adapter_Exception;
+use function PHPUnit\Framework\throwException;
 
 class WebCheckout
 {
@@ -151,7 +153,7 @@ class WebCheckout
         if ($header !== 'application/json') {
             $response->setHttpResponseCode(404);
             $response->sendResponse();
-            fastcgi_finish_request();
+            $this->closeRequest();
             throw new BadHeaderException('Invalid Content-Type given.');
         }
 
@@ -255,5 +257,17 @@ class WebCheckout
         }
 
         return session_id();
+    }
+
+    public function closeRequest() {
+
+        if (function_exists('fastcgi_finish_request')) {
+            fastcgi_finish_request();
+            return;
+        }
+
+        ob_end_flush();
+        flush();
+        exit(); //NOSONAR
     }
 }


### PR DESCRIPTION
# Pull Request Template

## Description

Remove exit() after sending the response and use fastcgi_finish_request() instead - so shopware should no longer reject the plugin.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
