### PR TITLE
Sg 189 akf guest login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/) and this 
 ### Added
 - ability to skip category export when calling `get_items`, config called `skip_category_assignment`
 - ability to skip advanced price export when calling `get_items`, config called `skip_advanced_price_export`
+- webCheckout login route for guests
+- webCheckout will close browser when an item is added to cart on desktop site (inApp)
 ### Changed
 - category querying and lookup to be more performant
 

--- a/src/Backend/SgateShopgatePlugin/Bootstrap.php
+++ b/src/Backend/SgateShopgatePlugin/Bootstrap.php
@@ -468,6 +468,12 @@ class Shopware_Plugins_Backend_SgateShopgatePlugin_Bootstrap extends Shopware_Co
               'onFrontendCustom'
             );
 
+            // WebCheckout for product view
+            $this->subscribeEvent(
+                'Enlight_Controller_Action_PostDispatchSecure_Frontend_Detail',
+                'onFrontendCustom'
+            );
+
             $this->subscribeEvent(
                 'Enlight_Controller_Action_Frontend_Account_Password',
                 'onFrontendPassword'
@@ -1474,7 +1480,6 @@ class Shopware_Plugins_Backend_SgateShopgatePlugin_Bootstrap extends Shopware_Co
 
     public function onFrontendCustom(Enlight_Event_EventArgs $args)
     {
-        // todo: possibly create event to post back guest session to App on product page
         $view = $args->getSubject()->View();
         $view->addTemplateDir($this->Path() . 'Views/');
         $view->assign('sgWebCheckout', $this->isInWebView($args));

--- a/src/Backend/SgateShopgatePlugin/Bootstrap.php
+++ b/src/Backend/SgateShopgatePlugin/Bootstrap.php
@@ -155,7 +155,7 @@ class Shopware_Plugins_Backend_SgateShopgatePlugin_Bootstrap extends Shopware_Co
      */
     public function getVersion()
     {
-        return '2.9.113';
+        return '2.9.114-alpha.1';
     }
 
     /**

--- a/src/Backend/SgateShopgatePlugin/Bootstrap.php
+++ b/src/Backend/SgateShopgatePlugin/Bootstrap.php
@@ -1474,6 +1474,7 @@ class Shopware_Plugins_Backend_SgateShopgatePlugin_Bootstrap extends Shopware_Co
 
     public function onFrontendCustom(Enlight_Event_EventArgs $args)
     {
+        // todo: possibly create event to post back guest session to App on product page
         $view = $args->getSubject()->View();
         $view->addTemplateDir($this->Path() . 'Views/');
         $view->assign('sgWebCheckout', $this->isInWebView($args));
@@ -1543,7 +1544,7 @@ class Shopware_Plugins_Backend_SgateShopgatePlugin_Bootstrap extends Shopware_Co
      */
     private function getAttributesStore()
     {
-        if (version_compare(Shopware()->Config()->version, '5.2', '>=')) {
+        if ($this->assertMinimumVersion('5.2')) {
             $attributeHelper = new AttributeHelper();
             $attributesStore = $attributeHelper->getConfiguredAttributes(false);
         } else {

--- a/src/Backend/SgateShopgatePlugin/Components/User.php
+++ b/src/Backend/SgateShopgatePlugin/Components/User.php
@@ -1,26 +1,22 @@
 <?php
-
 /**
- * Shopware 5
- * Copyright (c) shopware AG
+ * Copyright Shopgate Inc.
  *
- * According to our dual licensing model, this program can be used either
- * under the terms of the GNU Affero General Public License, version 3,
- * or under a proprietary license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The texts of the GNU Affero General Public License with an additional
- * permission and of our proprietary license can be found at and
- * in the LICENSE file you have received along with this program.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- * "Shopware" is a registered trademark of shopware AG.
- * The licensing of the program under the AGPLv3 does not imply a
- * trademark license. Therefore any rights, title and interest in
- * our trademarks remain entirely with us.
+ * @author    Shopgate Inc, 804 Congress Ave, Austin, Texas 78701 <interfaces@shopgate.com>
+ * @copyright Shopgate Inc
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace Shopgate\Components;
@@ -30,12 +26,17 @@ use Doctrine\ORM\ORMException;
 use Doctrine\ORM\TransactionRequiredException;
 use Enlight_Components_Session_Namespace;
 use Enlight_Controller_Request_Request;
+use Enlight_Controller_Request_RequestHttp;
 use Enlight_Controller_Response_Response;
+use Enlight_Event_Exception;
+use Enlight_Exception;
 use Exception;
 use sAdmin;
 use sBasket;
 use Shopgate\Helpers\WebCheckout;
 use Shopware\Components\DependencyInjection\Container;
+use Symfony\Component\Form\FormInterface;
+use Zend_Db_Adapter_Exception;
 
 class User
 {
@@ -84,6 +85,10 @@ class User
     /**
      * @param Enlight_Controller_Request_Request   $request
      * @param Enlight_Controller_Response_Response $httpResponse
+     *
+     * @throws Enlight_Event_Exception
+     * @throws Enlight_Exception
+     * @throws Zend_Db_Adapter_Exception
      */
     public function loginUser($request, $httpResponse)
     {
@@ -175,7 +180,7 @@ class User
     /**
      * Custom get user action
      *
-     * @param Enlight_Controller_Request_Request $request
+     * @param Enlight_Controller_Request_RequestHttp $request
      */
     public function getUser($request)
     {
@@ -330,9 +335,10 @@ class User
      * @param Enlight_Controller_Request_Request   $request
      * @param Enlight_Controller_Response_Response $httpResponse
      *
-     * @throws ORMException
      * @throws OptimisticLockException
      * @throws TransactionRequiredException
+     * @throws Exception
+     * @throws ORMException
      *
      * @return array
      */
@@ -389,7 +395,7 @@ class User
      *
      * @throws Exception
      *
-     * @return Form
+     * @return FormInterface
      */
     protected function createForm($type, $data = null, array $options = [])
     {
@@ -414,7 +420,7 @@ class User
         $scopedRegistration = $mainShop->getCustomerScope();
 
         $addScopeSql = '';
-        if ($scopedRegistration == true) {
+        if ($scopedRegistration) {
             $addScopeSql = Shopware()->Db()->quoteInto(' AND subshopID = ? ', $mainShop->getId());
         }
 
@@ -454,10 +460,8 @@ class User
             AND UNIX_TIMESTAMP(lastlogin) >= (UNIX_TIMESTAMP(now())-?)
         ';
 
-        $user = Shopware()->Db()->fetchRow(
+        return Shopware()->Db()->fetchRow(
             $sql, [$hash, $email, $userId, 7200]
         );
-
-        return $user;
     }
 }

--- a/src/Backend/SgateShopgatePlugin/Controllers/Frontend/shopgate.php
+++ b/src/Backend/SgateShopgatePlugin/Controllers/Frontend/shopgate.php
@@ -642,8 +642,6 @@ class Shopware_Controllers_Frontend_Shopgate extends Enlight_Controller_Action i
         }
 
         $this->loginHelper();
-        // forward 'libshopgate' user-agent if it exists
-        $this->Response()->setHeader('User-Agent', $this->Request()->getHeader('User-Agent'));
         $redirect && $this->redirect(str_replace('.', '/', $redirect));
     }
 

--- a/src/Backend/SgateShopgatePlugin/Controllers/Frontend/shopgate.php
+++ b/src/Backend/SgateShopgatePlugin/Controllers/Frontend/shopgate.php
@@ -623,21 +623,27 @@ class Shopware_Controllers_Frontend_Shopgate extends Enlight_Controller_Action i
     }
 
     /**
+     * Logs in someone & redirects them to a SW5 page,
+     * not meant to be used by API, but for WebCheckout
+     *
      * @return void
-     * @throws \Exception
+     * @throws Exception
      */
     public function loginAction()
     {
         if (!$this->Request()->isGet()) {
             return;
         }
-        $redirect = $this->Request()->get('redirectTo', 'index');
 
+        $redirect = $this->Request()->get('redirectTo', 'index');
+        // to prevent malicious off-site redirect usage
         if (str_contains($redirect, 'http')) {
             return;
         }
 
         $this->loginHelper();
+        // forward 'libshopgate' user-agent if it exists
+        $this->Response()->setHeader('User-Agent', $this->Request()->getHeader('User-Agent'));
         $redirect && $this->redirect(str_replace('.', '/', $redirect));
     }
 

--- a/src/Backend/SgateShopgatePlugin/Helpers/WebCheckout.php
+++ b/src/Backend/SgateShopgatePlugin/Helpers/WebCheckout.php
@@ -42,7 +42,7 @@ class WebCheckout
     /**
      * Login app user from JWT token
      *
-     * @param                                    $token
+     * @param ?string $token
      * @param Enlight_Controller_Request_Request $request
      *
      * @return bool
@@ -53,90 +53,59 @@ class WebCheckout
      */
     public function loginAppUser($token, $request)
     {
-        $basket  = Shopware()->Modules()->Basket()->sGetBasket();
-        $voucher = $this->getVoucher();
-
-        if (isset($token)) {
-            $key               = trim($this->getConfig()->getApikey());
-            JWT::$leeway       = 300;
-            $decoded           = JWT::decode($token, new Key($key, 'HS256'));
-            $decoded           = json_decode(json_encode($decoded), true);
-            $customerId        = $decoded['customer_id'];
-            $promotionVouchers = json_decode($decoded['promotion_vouchers'], true);
-
-            if (isset($promotionVouchers)) {
-                Shopware()->Session()->offsetSet('promotionVouchers', $promotionVouchers);
-            }
-
-            $sql = ' SELECT id, password, email, password_change_date FROM s_user WHERE customernumber = ? AND active=1 AND (lockeduntil < now() OR lockeduntil IS NULL) ';
-            $user = Shopware()->Db()->fetchAll($sql, array($customerId)) ?: array();
-
-            if (count($user) > 1) {
-                return false;
-            }
-
-            /**
-             * Anti-CAPTCHA:
-             *
-             * During initialization, the system sometimes sets the Bot flag
-             * in the session depending on the user agent. If the flag is set,
-             * the session is scrapped and certain features, like adding
-             * articles to the cart, are disabled. It's not always possible to
-             * trick the system by spoofind the user agent so it's necessary
-             * to explicitly disable the flag here or risk the cart items not
-             * being set, resulting in a cleared cart upon login.
-             *
-             * @see ./Shopware/Plugins/Default/Core/System/Bootstrap.php:102 @onInitResourceSystem
-             * @see ./Shopware/Core/sBasket.php:1804 @sAddArticle
-             */
-            if (Shopware()->Session()->Bot) {
-                Shopware()->Session()->Bot = false;
-            }
-
-            $request->setPost('email', $user[0]["email"]);
-            $request->setPost('passwordMD5', $user[0]["password"]);
-
-            $checkUser = Shopware()->Modules()->Admin()->sLogin(true);
-
-            if (isset($checkUser['sErrorFlag'])) {
-                throw new Exception($checkUser['sErrorMessages'][0], 400);
-            }
-            Shopware()->Session()->offsetSet('sUserId', $user[0]['id']);
-            Shopware()->Session()->offsetSet('sUserPasswordChangeDate', $user[0]['password_change_date']);
-
-            return true;
+        if (!$token) {
+            return false;
         }
 
-        return false;
-    }
+        Shopware()->Modules()->Basket()->sGetBasket();
+        $decoded = $this->getJWT($token);
+        if (!$decoded || isset($decoded['error'])) {
+            return false;
+        }
+        $customerId = $decoded['customer_id'];
+        $promotionVouchers = json_decode($decoded['promotion_vouchers'], true);
 
-    /**
-     * Returns the current basket voucher or false
-     *
-     * @return array|false
-     */
-    public function getVoucher()
-    {
-        $voucher = Shopware()->Db()->fetchRow(
-            'SELECT id basketID, ordernumber, articleID as voucherID
-                FROM s_order_basket
-                WHERE modus = 2 AND sessionID = ?',
-            array(Shopware()->Session()->get('sessionId'))
-        );
-        if (!empty($voucher)) {
-            $voucher['code'] = Shopware()->Db()->fetchOne(
-                'SELECT vouchercode FROM s_emarketing_vouchers WHERE ordercode = ?',
-                array($voucher['ordernumber'])
-            );
-            if (empty($voucher['code'])) {
-                $voucher['code'] = Shopware()->Db()->fetchOne(
-                    'SELECT code FROM s_emarketing_voucher_codes WHERE id = ?',
-                    array($voucher['voucherID'])
-                );
-            }
+        if (isset($promotionVouchers)) {
+            Shopware()->Session()->offsetSet('promotionVouchers', $promotionVouchers);
         }
 
-        return $voucher;
+        $sql = ' SELECT id, password, email, password_change_date FROM s_user WHERE customernumber = ? AND active=1 AND (lockeduntil < now() OR lockeduntil IS NULL) ';
+        $user = Shopware()->Db()->fetchAll($sql, [$customerId]) ?: [];
+
+        if (count($user) > 1) {
+            return false;
+        }
+
+        /**
+         * Anti-CAPTCHA:
+         *
+         * During initialization, the system sometimes sets the Bot flag
+         * in the session depending on the user agent. If the flag is set,
+         * the session is scrapped and certain features, like adding
+         * articles to the cart, are disabled. It's not always possible to
+         * trick the system by spoofind the user agent so it's necessary
+         * to explicitly disable the flag here or risk the cart items not
+         * being set, resulting in a cleared cart upon login.
+         *
+         * @see ./Shopware/Plugins/Default/Core/System/Bootstrap.php:102 @onInitResourceSystem
+         * @see ./Shopware/Core/sBasket.php:1804 @sAddArticle
+         */
+        if (Shopware()->Session()->Bot) {
+            Shopware()->Session()->Bot = false;
+        }
+
+        $request->setPost('email', $user[0]['email']);
+        $request->setPost('passwordMD5', $user[0]['password']);
+
+        $checkUser = Shopware()->Modules()->Admin()->sLogin(true);
+
+        if (isset($checkUser['sErrorFlag'])) {
+            throw new Exception($checkUser['sErrorMessages'][0], 400);
+        }
+        Shopware()->Session()->offsetSet('sUserId', $user[0]['id']);
+        Shopware()->Session()->offsetSet('sUserPasswordChangeDate', $user[0]['password_change_date']);
+
+        return true;
     }
 
     /**
@@ -162,9 +131,9 @@ class WebCheckout
     }
 
     /**
-     * @param $token
+     * @param string $token
      *
-     * @return array
+     * @return array|false|null
      */
     public function getJWT($token)
     {
@@ -180,6 +149,25 @@ class WebCheckout
                 'message' => $error->getMessage()
             );
         }
+    }
+
+    /**
+     * @param \Enlight_Controller_Request_RequestHttp $request
+     * @return string
+     */
+    public function getTokenFromCall($request)
+    {
+        $token = $request->getCookie('token') ?: $request->getParam('token');
+        if (!$token) {
+            try {
+                $auth = $request->getHeader('Authorization');
+                $token = str_contains($auth, 'Bearer') ? str_replace('Bearer ', '', $auth) : '';
+            } catch (Exception $e) {
+                return '';
+            }
+        }
+
+        return $token ?: '';
     }
 
 

--- a/src/Backend/SgateShopgatePlugin/Views/frontend/_resources/js/jquery.shopgate.js
+++ b/src/Backend/SgateShopgatePlugin/Views/frontend/_resources/js/jquery.shopgate.js
@@ -15,7 +15,20 @@
                     return sParameterName[1] === undefined ? true : decodeURIComponent(sParameterName[1]);
                 }
             }
-        };
+        }
+
+        function closeBrowser (redirect = '/') {
+            const commands = [
+                {
+                    'c': 'broadcastEvent',
+                    'p': {
+                        'event': 'closeInAppBrowser',
+                        'parameters': [{ 'redirectTo': redirect }]
+                    }
+                }
+            ]
+            window.SGAppConnector.sendAppCommands(commands);
+        }
 
         function payPalPayment(event, me) {
 
@@ -25,17 +38,7 @@
                     urlToken = getUrlParameter('token');
 
                 if (window.location.href.includes('/token/') || (urlToken && urlToken.length > 1)) {
-                    var commands = [
-                        {
-                            'c': 'broadcastEvent',
-                            'p': {
-                                'event': 'closeInAppBrowser',
-                                'parameters': [{'redirectTo': '/cart'}]
-                            }
-                        }
-                    ];
-                    window.SGAppConnector.sendAppCommands(commands);
-
+                    closeBrowser('/cart');
                 } else {
                     if (CSRF.checkToken()) {
                         token = CSRF.getToken();
@@ -58,5 +61,6 @@
         }
 
         $.subscribe('plugin/swagPayPalUnifiedExpressCheckoutButtonCart/createButton', payPalPayment);
+        $.subscribe('plugin/swAddArticle/onAddArticle', closeBrowser); // supposedly only product detail page
     });
 })(jQuery, window);

--- a/src/Backend/SgateShopgatePlugin/Views/frontend/_resources/js/jquery.shopgate.js
+++ b/src/Backend/SgateShopgatePlugin/Views/frontend/_resources/js/jquery.shopgate.js
@@ -17,17 +17,16 @@
             }
         }
 
-        function closeBrowser (redirect = '/') {
-            const commands = [
-                {
-                    'c': 'broadcastEvent',
-                    'p': {
-                        'event': 'closeInAppBrowser',
-                        'parameters': [{ 'redirectTo': redirect }]
-                    }
-                }
-            ]
-            window.SGAppConnector.sendAppCommands(commands);
+        function closeBrowser () {
+            window.SGAppConnector.sendAppCommand(
+              {
+                  'c': 'broadcastEvent',
+                  'p': {
+                      'event': 'closeInAppBrowser',
+                      'parameters': [{'redirectTo': '/cart'}]
+                  }
+              }
+            );
         }
 
         function payPalPayment(event, me) {
@@ -38,7 +37,7 @@
                     urlToken = getUrlParameter('token');
 
                 if (window.location.href.includes('/token/') || (urlToken && urlToken.length > 1)) {
-                    closeBrowser('/cart');
+                    closeBrowser();
                 } else {
                     if (CSRF.checkToken()) {
                         token = CSRF.getToken();

--- a/src/Backend/SgateShopgatePlugin/Views/frontend/index/index.tpl
+++ b/src/Backend/SgateShopgatePlugin/Views/frontend/index/index.tpl
@@ -36,7 +36,8 @@
                 {/literal}
             </script>
             <style type="text/css">
-                .is--act-cart {ldelim}display: none{rdelim}
+                .is--act-cart,
+                .content--breadcrumb {ldelim}display: none{rdelim}
                 {$sgCustomCss}
             </style>
             {if $sgSessionId || $sgActionName === 'confirm' || $sgActionName === 'shippingPayment' ||  $sgActionName === 'cart'}

--- a/src/Backend/SgateShopgatePlugin/plugin.xml
+++ b/src/Backend/SgateShopgatePlugin/plugin.xml
@@ -3,16 +3,22 @@
         xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/5.3/engine/Shopware/Components/Plugin/schema/plugin.xsd">
     <label lang="de">Swag Plugin System</label>
     <label lang="en">Swag plugin system</label>
-    <version>2.9.113</version>
+    <version>2.9.114-alpha.1</version>
     <copyright>(c) by Shopgate GmbH</copyright>
     <license>Apache</license>
     <link>https://store.shopware.com/sgate00633f/shopgate-mobile-commerce-fuer-shopware.html</link>
     <author>Shopgate GmbH</author>
     <compatibility minVersion="5.3.0"/>
-    <changelog version="2.9.113">
+    <changelog version="2.9.114-alpha.1">
         <changes lang="en">
-            ### Fixed
-            - removed unused reference to a PHPUnit class or function in production code
+            ### Added
+            - ability to skip category export when calling `get_items`, config called `skip_category_assignment`
+            - ability to skip advanced price export when calling `get_items`, config called `skip_advanced_price_export`
+            - webCheckout login route for guests
+            - webCheckout will close browser when an item is added to cart on desktop site (inApp)
+
+            ### Changed
+            - category querying and lookup to be more performant
         </changes>
     </changelog>
     <description>

--- a/tests/Postman/collection.json
+++ b/tests/Postman/collection.json
@@ -1,2021 +1,2021 @@
 {
-    "info": {
-        "_postman_id": "72babe50-8d15-4025-b1b2-bf064719644a",
-        "name": "Shopware 5 (Go)",
-        "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-        "_exporter_id": "5289226"
-    },
-    "item": [
+  "info": {
+    "_postman_id": "72babe50-8d15-4025-b1b2-bf064719644a",
+    "name": "Shopware 5 (Go)",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "5289226"
+  },
+  "item": [
+    {
+      "name": "Init",
+      "item": [
         {
-            "name": "Init",
-            "item": [
-                {
-                    "name": "System",
-                    "item": [
-                        {
-                            "name": "SW: Get shop info",
-                            "event": [
-                                {
-                                    "listen": "prerequest",
-                                    "script": {
-                                        "exec": [
-                                            "// allowCookie=1\r",
-                                            "const jar = pm.cookies.jar();\r",
-                                            "jar.set(pm.environment.get(\"host\"), 'allowCookie', '1');"
-                                        ],
-                                        "type": "text/javascript"
-                                    }
-                                }
-                            ],
-                            "request": {
-                                "method": "GET",
-                                "header": [],
-                                "url": {
-                                    "raw": "{{sw_endpoint_api}}/shops/1",
-                                    "host": [
-                                        "{{sw_endpoint_api}}"
-                                    ],
-                                    "path": [
-                                        "shops",
-                                        "1"
-                                    ]
-                                }
-                            },
-                            "response": []
-                        }
-                    ]
-                },
-                {
-                    "name": "Product",
-                    "item": [
-                        {
-                            "name": "SW: Get main product",
-                            "event": [
-                                {
-                                    "listen": "test",
-                                    "script": {
-                                        "exec": [
-                                            "pm.test(\"Status code is 200\", function () {\r",
-                                            "    pm.response.to.have.status(200);\r",
-                                            "});\r",
-                                            "\r",
-                                            "pm.test(\"Get main product\", function () {\r",
-                                            "    var jsonData = pm.response.json();\r",
-                                            "    pm.expect(jsonData.data).to.haveOwnProperty('id').to.be.a('number');\r",
-                                            "    pm.environment.set(\"gen_product_main_id\", jsonData.data.id);\r",
-                                            "});"
-                                        ],
-                                        "type": "text/javascript"
-                                    }
-                                }
-                            ],
-                            "request": {
-                                "method": "GET",
-                                "header": [],
-                                "url": {
-                                    "raw": "{{sw_endpoint_api}}/articles/SW10001?useNumberAsId=true",
-                                    "host": [
-                                        "{{sw_endpoint_api}}"
-                                    ],
-                                    "path": [
-                                        "articles",
-                                        "SW10001"
-                                    ],
-                                    "query": [
-                                        {
-                                            "key": "useNumberAsId",
-                                            "value": "true"
-                                        }
-                                    ]
-                                }
-                            },
-                            "response": []
-                        },
-                        {
-                            "name": "SW: Get main category",
-                            "event": [
-                                {
-                                    "listen": "test",
-                                    "script": {
-                                        "exec": [
-                                            "pm.test(\"Status code is 200\", function () {\r",
-                                            "    pm.response.to.have.status(200);\r",
-                                            "});\r",
-                                            "\r",
-                                            "pm.test(\"Get main category\", function () {\r",
-                                            "    var jsonData = pm.response.json();\r",
-                                            "    pm.expect(jsonData.data[0]).to.haveOwnProperty('id').to.be.a('number');\r",
-                                            "    pm.environment.set(\"gen_category_main_id\", jsonData.data[0].id);\r",
-                                            "});"
-                                        ],
-                                        "type": "text/javascript"
-                                    }
-                                }
-                            ],
-                            "protocolProfileBehavior": {
-                                "disableBodyPruning": true
-                            },
-                            "request": {
-                                "method": "GET",
-                                "header": [],
-                                "body": {
-                                    "mode": "raw",
-                                    "raw": "{\r\n    \"filter\": [\r\n        {\r\n            \"property\": \"parentId\",\r\n            \"expression\": \">\",\r\n            \"value\": \"1\"\r\n        }\r\n    ],\r\n    \"limit\": 1\r\n}",
-                                    "options": {
-                                        "raw": {
-                                            "language": "json"
-                                        }
-                                    }
-                                },
-                                "url": {
-                                    "raw": "{{sw_endpoint_api}}/categories",
-                                    "host": [
-                                        "{{sw_endpoint_api}}"
-                                    ],
-                                    "path": [
-                                        "categories"
-                                    ]
-                                }
-                            },
-                            "response": []
-                        },
-                        {
-                            "name": "SW: create inactive prod",
-                            "event": [
-                                {
-                                    "listen": "test",
-                                    "script": {
-                                        "exec": [
-                                            "pm.test(\"Status code is 201\", function () {\r",
-                                            "    pm.response.to.have.status(201);\r",
-                                            "});\r",
-                                            "\r",
-                                            "pm.test(\"Get id of created product\", function () {\r",
-                                            "    var jsonData = pm.response.json();\r",
-                                            "    pm.expect(jsonData.data.id).to.be.a(\"number\");\r",
-                                            "    pm.environment.set('created_product1_id', jsonData.data.id);\r",
-                                            "});"
-                                        ],
-                                        "type": "text/javascript"
-                                    }
-                                }
-                            ],
-                            "request": {
-                                "method": "POST",
-                                "header": [],
-                                "body": {
-                                    "mode": "raw",
-                                    "raw": "{\r\n    \"name\": \"API: disabled product\",\r\n    \"active\": false,\r\n    \"tax\": 19,\r\n    \"supplier\": \"Sport Shoes Inc.\",\r\n    \"categories\": [\r\n        {\r\n            \"id\": {{gen_category_main_id}}\r\n        }\r\n    ],\r\n    \"mainDetail\": {\r\n        \"number\": \"API-INACTIVE\",\r\n        \"active\": true,\r\n        \"prices\": [\r\n            {\r\n                \"customerGroupKey\": \"EK\",\r\n                \"price\": 999\r\n            }\r\n        ]\r\n    }\r\n}",
-                                    "options": {
-                                        "raw": {
-                                            "language": "json"
-                                        }
-                                    }
-                                },
-                                "url": {
-                                    "raw": "{{sw_endpoint_api}}/articles",
-                                    "host": [
-                                        "{{sw_endpoint_api}}"
-                                    ],
-                                    "path": [
-                                        "articles"
-                                    ]
-                                }
-                            },
-                            "response": []
-                        },
-                        {
-                            "name": "SW: create price grp",
-                            "event": [
-                                {
-                                    "listen": "test",
-                                    "script": {
-                                        "exec": [
-                                            "pm.test(\"Status code is 201\", function () {\r",
-                                            "    pm.response.to.have.status(201);\r",
-                                            "});\r",
-                                            "\r",
-                                            "pm.test(\"Get id of created product\", function () {\r",
-                                            "    var jsonData = pm.response.json();\r",
-                                            "    pm.expect(jsonData.data.id).to.be.a(\"number\");\r",
-                                            "    pm.environment.set('created_product2_id', jsonData.data.id);\r",
-                                            "});"
-                                        ],
-                                        "type": "text/javascript"
-                                    }
-                                }
-                            ],
-                            "request": {
-                                "method": "POST",
-                                "header": [],
-                                "body": {
-                                    "mode": "raw",
-                                    "raw": "{\r\n    \"name\": \"API: price grp product\",\r\n    \"active\": true,\r\n    \"tax\": 19,\r\n    \"supplier\": \"Active Runners LLC\",\r\n    \"categories\": [\r\n        {\r\n            \"id\": {{gen_category_main_id}}\r\n        }\r\n    ],\r\n    \"lastStock\": true, // stock cannot go into negatives (saleable)\r\n    \"priceGroupActive\": true,\r\n    \"priceGroupId\": 500,\r\n    \"mainDetail\": {\r\n        \"number\": \"API-PRICE-GRP\",\r\n        \"active\": true,\r\n        \"prices\": [\r\n            {\r\n                \"customerGroupKey\": \"EK\",\r\n                \"from\": \"1\",\r\n                \"to\": \"3\",\r\n                \"price\": 200,\r\n                \"pseudoPrice\": 250, // fake price to cross out\r\n                \"basePrice\": 90\r\n            },\r\n            {\r\n                \"customerGroupKey\": \"EK\",\r\n                \"from\": \"4\",\r\n                \"to\": \"7\",\r\n                \"price\": 100,\r\n                \"pseudoPrice\": 250,\r\n                \"basePrice\": 90\r\n            }\r\n        ],\r\n        \"inStock\": 500,\r\n        \"minPurchase\": 2,\r\n        \"maxPurchase\": 10,\r\n        \"purchaseSteps\": 2,\r\n        \"position\": 5\r\n    }\r\n}",
-                                    "options": {
-                                        "raw": {
-                                            "language": "json"
-                                        }
-                                    }
-                                },
-                                "url": {
-                                    "raw": "{{sw_endpoint_api}}/articles",
-                                    "host": [
-                                        "{{sw_endpoint_api}}"
-                                    ],
-                                    "path": [
-                                        "articles"
-                                    ]
-                                }
-                            },
-                            "response": []
-                        }
-                    ]
-                }
-            ]
-        },
-        {
-            "name": "Catalog",
-            "item": [
-                {
-                    "name": "Export inactive",
-                    "item": [
-                        {
-                            "name": "SG: try inactive export",
-                            "event": [
-                                {
-                                    "listen": "test",
-                                    "script": {
-                                        "exec": [
-                                            "pm.test(\"Status code is 200\", function () {",
-                                            "    pm.response.to.have.status(200);",
-                                            "});",
-                                            "",
-                                            "pm.test(\"Make sure the product is not exported as it's inactive\", function () {",
-                                            "    var jsonData = pm.response.json();",
-                                            "    pm.expect(jsonData.error).to.eql(82);",
-                                            "});"
-                                        ],
-                                        "type": "text/javascript"
-                                    }
-                                }
-                            ],
-                            "request": {
-                                "method": "POST",
-                                "header": [
-                                    {
-                                        "key": "Accept",
-                                        "value": "*/*"
-                                    },
-                                    {
-                                        "key": "X-Shopgate-Auth-User",
-                                        "value": "{{gen_sg_header_auth_user}}"
-                                    },
-                                    {
-                                        "key": "X-Shopgate-Auth-Token",
-                                        "value": "{{gen_sg_header_auth_token}}"
-                                    }
-                                ],
-                                "body": {
-                                    "mode": "formdata",
-                                    "formdata": [
-                                        {
-                                            "key": "shop_number",
-                                            "value": "{{sg_shop_number}}",
-                                            "type": "text"
-                                        },
-                                        {
-                                            "key": "action",
-                                            "value": "{{framework_action_get_items}}",
-                                            "type": "text"
-                                        },
-                                        {
-                                            "key": "limit",
-                                            "value": "5",
-                                            "type": "text"
-                                        },
-                                        {
-                                            "key": "offset",
-                                            "value": "0",
-                                            "type": "text"
-                                        },
-                                        {
-                                            "key": "uids[]",
-                                            "value": "{{created_product1_id}}",
-                                            "type": "text"
-                                        }
-                                    ]
-                                },
-                                "url": {
-                                    "raw": "{{sg_endpoint_api}}/getItems",
-                                    "host": [
-                                        "{{sg_endpoint_api}}"
-                                    ],
-                                    "path": [
-                                        "getItems"
-                                    ]
-                                }
-                            },
-                            "response": []
-                        },
-                        {
-                            "name": "SG: set export inactive",
-                            "event": [
-                                {
-                                    "listen": "test",
-                                    "script": {
-                                        "exec": [
-                                            "pm.test(\"Status code is 200\", function () {",
-                                            "    pm.response.to.have.status(200);",
-                                            "});",
-                                            "",
-                                            "pm.test(\"enable inactive product export\", function () {",
-                                            "    var jsonData = pm.response.json();",
-                                            "    pm.expect(jsonData.shopgate_settings).lengthOf(1);",
-                                            "    pm.expect(jsonData.shopgate_settings[0].new).to.eq(\"1\");",
-                                            "});"
-                                        ],
-                                        "type": "text/javascript"
-                                    }
-                                }
-                            ],
-                            "request": {
-                                "method": "POST",
-                                "header": [
-                                    {
-                                        "key": "X-Shopgate-Auth-User",
-                                        "value": "{{gen_sg_header_auth_user}}"
-                                    },
-                                    {
-                                        "key": "X-Shopgate-Auth-Token",
-                                        "value": "{{gen_sg_header_auth_token}}"
-                                    }
-                                ],
-                                "body": {
-                                    "mode": "formdata",
-                                    "formdata": [
-                                        {
-                                            "key": "shop_number",
-                                            "value": "{{sg_shop_number}}",
-                                            "type": "text"
-                                        },
-                                        {
-                                            "key": "action",
-                                            "value": "{{framework_action_set_settings}}",
-                                            "type": "text"
-                                        },
-                                        {
-                                            "key": "shopgate_settings[0][name]",
-                                            "value": "export_product_inactive",
-                                            "type": "text"
-                                        },
-                                        {
-                                            "key": "shopgate_settings[0][value]",
-                                            "value": "1",
-                                            "type": "text"
-                                        }
-                                    ]
-                                },
-                                "url": {
-                                    "raw": "{{sg_endpoint_api}}/setSettings",
-                                    "host": [
-                                        "{{sg_endpoint_api}}"
-                                    ],
-                                    "path": [
-                                        "setSettings"
-                                    ]
-                                }
-                            },
-                            "response": []
-                        },
-                        {
-                            "name": "SW: config cache clear",
-                            "event": [
-                                {
-                                    "listen": "test",
-                                    "script": {
-                                        "exec": [
-                                            "pm.test(\"Status code is 200\", function () {\r",
-                                            "    pm.response.to.have.status(200);\r",
-                                            "});"
-                                        ],
-                                        "type": "text/javascript"
-                                    }
-                                }
-                            ],
-                            "request": {
-                                "method": "DELETE",
-                                "header": [],
-                                "url": {
-                                    "raw": "{{sw_endpoint_api}}/caches/config",
-                                    "host": [
-                                        "{{sw_endpoint_api}}"
-                                    ],
-                                    "path": [
-                                        "caches",
-                                        "config"
-                                    ]
-                                }
-                            },
-                            "response": []
-                        },
-                        {
-                            "name": "SG: try inactive export",
-                            "event": [
-                                {
-                                    "listen": "test",
-                                    "script": {
-                                        "exec": [
-                                            "pm.test(\"Status code is 200\", function () {",
-                                            "    pm.response.to.have.status(200);",
-                                            "});",
-                                            "",
-                                            "pm.test(\"Not an error\", function () {",
-                                            "    pm.response.to.not.have.jsonBody('error');",
-                                            "});",
-                                            "",
-                                            "pm.test(\"Check product gets exported now\", function () {",
-                                            "    var jsonObject = xml2Json(responseBody);",
-                                            "    pm.expect(jsonObject.items.item.$.uid).to.eql(pm.environment.get('created_product1_id').toString());",
-                                            "    pm.expect(jsonObject.items.item.stock.is_saleable).to.eq('0');",
-                                            "});"
-                                        ],
-                                        "type": "text/javascript"
-                                    }
-                                }
-                            ],
-                            "request": {
-                                "method": "POST",
-                                "header": [
-                                    {
-                                        "key": "Accept",
-                                        "value": "*/*"
-                                    },
-                                    {
-                                        "key": "X-Shopgate-Auth-User",
-                                        "value": "{{gen_sg_header_auth_user}}"
-                                    },
-                                    {
-                                        "key": "X-Shopgate-Auth-Token",
-                                        "value": "{{gen_sg_header_auth_token}}"
-                                    }
-                                ],
-                                "body": {
-                                    "mode": "formdata",
-                                    "formdata": [
-                                        {
-                                            "key": "shop_number",
-                                            "value": "{{sg_shop_number}}",
-                                            "type": "text"
-                                        },
-                                        {
-                                            "key": "action",
-                                            "value": "{{framework_action_get_items}}",
-                                            "type": "text"
-                                        },
-                                        {
-                                            "key": "limit",
-                                            "value": "5",
-                                            "type": "text"
-                                        },
-                                        {
-                                            "key": "offset",
-                                            "value": "0",
-                                            "type": "text"
-                                        },
-                                        {
-                                            "key": "uids[]",
-                                            "value": "{{created_product1_id}}",
-                                            "type": "text"
-                                        }
-                                    ]
-                                },
-                                "url": {
-                                    "raw": "{{sg_endpoint_api}}/getItems",
-                                    "host": [
-                                        "{{sg_endpoint_api}}"
-                                    ],
-                                    "path": [
-                                        "getItems"
-                                    ]
-                                }
-                            },
-                            "response": []
-                        },
-                        {
-                            "name": "SG: unset export inactive",
-                            "event": [
-                                {
-                                    "listen": "test",
-                                    "script": {
-                                        "exec": [
-                                            "pm.test(\"Status code is 200\", function () {",
-                                            "    pm.response.to.have.status(200);",
-                                            "});",
-                                            "",
-                                            "pm.test(\"disable inactive product export\", function () {",
-                                            "    var jsonData = pm.response.json();",
-                                            "    pm.expect(jsonData.shopgate_settings).lengthOf(1);",
-                                            "    pm.expect(jsonData.shopgate_settings[0].new).to.eq(\"0\");",
-                                            "});"
-                                        ],
-                                        "type": "text/javascript"
-                                    }
-                                }
-                            ],
-                            "request": {
-                                "method": "POST",
-                                "header": [
-                                    {
-                                        "key": "X-Shopgate-Auth-User",
-                                        "value": "{{gen_sg_header_auth_user}}"
-                                    },
-                                    {
-                                        "key": "X-Shopgate-Auth-Token",
-                                        "value": "{{gen_sg_header_auth_token}}"
-                                    }
-                                ],
-                                "body": {
-                                    "mode": "formdata",
-                                    "formdata": [
-                                        {
-                                            "key": "shop_number",
-                                            "value": "{{sg_shop_number}}",
-                                            "type": "text"
-                                        },
-                                        {
-                                            "key": "action",
-                                            "value": "{{framework_action_set_settings}}",
-                                            "type": "text"
-                                        },
-                                        {
-                                            "key": "shopgate_settings[0][name]",
-                                            "value": "export_product_inactive",
-                                            "type": "text"
-                                        },
-                                        {
-                                            "key": "shopgate_settings[0][value]",
-                                            "value": "0",
-                                            "type": "text"
-                                        }
-                                    ]
-                                },
-                                "url": {
-                                    "raw": "{{sg_endpoint_api}}/setSettings",
-                                    "host": [
-                                        "{{sg_endpoint_api}}"
-                                    ],
-                                    "path": [
-                                        "setSettings"
-                                    ]
-                                }
-                            },
-                            "response": []
-                        },
-                        {
-                            "name": "SW: config cache clear",
-                            "event": [
-                                {
-                                    "listen": "test",
-                                    "script": {
-                                        "exec": [
-                                            "pm.test(\"Status code is 200\", function () {\r",
-                                            "    pm.response.to.have.status(200);\r",
-                                            "});"
-                                        ],
-                                        "type": "text/javascript"
-                                    }
-                                }
-                            ],
-                            "request": {
-                                "method": "DELETE",
-                                "header": [],
-                                "url": {
-                                    "raw": "{{sw_endpoint_api}}/caches/config",
-                                    "host": [
-                                        "{{sw_endpoint_api}}"
-                                    ],
-                                    "path": [
-                                        "caches",
-                                        "config"
-                                    ]
-                                }
-                            },
-                            "response": []
-                        }
-                    ],
-                    "description": "SG-145 feature request. Exporting inactive products configuration."
-                },
-                {
-                    "name": "Disable Cat Export",
-                    "item": [
-                        {
-                            "name": "SG: disable cat export",
-                            "event": [
-                                {
-                                    "listen": "test",
-                                    "script": {
-                                        "exec": [
-                                            "pm.test(\"Status code is 200\", function () {",
-                                            "    pm.response.to.have.status(200);",
-                                            "});",
-                                            "",
-                                            "pm.test(\"enable setting\", function () {",
-                                            "    var jsonData = pm.response.json();",
-                                            "    pm.expect(jsonData.shopgate_settings).lengthOf(1);",
-                                            "    pm.expect(jsonData.shopgate_settings[0].old).to.eq(\"0\");",
-                                            "    pm.expect(jsonData.shopgate_settings[0].new).to.eq(\"1\");",
-                                            "});"
-                                        ],
-                                        "type": "text/javascript"
-                                    }
-                                }
-                            ],
-                            "request": {
-                                "method": "POST",
-                                "header": [
-                                    {
-                                        "key": "X-Shopgate-Auth-User",
-                                        "value": "{{gen_sg_header_auth_user}}"
-                                    },
-                                    {
-                                        "key": "X-Shopgate-Auth-Token",
-                                        "value": "{{gen_sg_header_auth_token}}"
-                                    }
-                                ],
-                                "body": {
-                                    "mode": "formdata",
-                                    "formdata": [
-                                        {
-                                            "key": "shop_number",
-                                            "value": "{{sg_shop_number}}",
-                                            "type": "text"
-                                        },
-                                        {
-                                            "key": "action",
-                                            "value": "{{framework_action_set_settings}}",
-                                            "type": "text"
-                                        },
-                                        {
-                                            "key": "shopgate_settings[0][name]",
-                                            "value": "skip_category_assignment",
-                                            "type": "text"
-                                        },
-                                        {
-                                            "key": "shopgate_settings[0][value]",
-                                            "value": "1",
-                                            "type": "text"
-                                        }
-                                    ]
-                                },
-                                "url": {
-                                    "raw": "{{sg_endpoint_api}}/setSettings",
-                                    "host": [
-                                        "{{sg_endpoint_api}}"
-                                    ],
-                                    "path": [
-                                        "setSettings"
-                                    ]
-                                }
-                            },
-                            "response": []
-                        },
-                        {
-                            "name": "SG: get items w/o cats",
-                            "event": [
-                                {
-                                    "listen": "test",
-                                    "script": {
-                                        "exec": [
-                                            "pm.test(\"Status code is 200\", function () {",
-                                            "    pm.response.to.have.status(200);",
-                                            "});",
-                                            "",
-                                            "pm.test(\"Not an error\", function () {",
-                                            "    pm.response.to.not.have.jsonBody('error');",
-                                            "});",
-                                            "",
-                                            "var jsonObject = xml2Json(responseBody);",
-                                            "pm.test(\"Check products have no categories exported\", function () {",
-                                            "    console.log(jsonObject)",
-                                            "    jsonObject.items.item.forEach(item => {",
-                                            "        pm.expect(item.categories.category).to.be.undefined;",
-                                            "    });",
-                                            "});"
-                                        ],
-                                        "type": "text/javascript"
-                                    }
-                                }
-                            ],
-                            "request": {
-                                "method": "POST",
-                                "header": [
-                                    {
-                                        "key": "Accept",
-                                        "value": "*/*"
-                                    },
-                                    {
-                                        "key": "X-Shopgate-Auth-User",
-                                        "value": "{{gen_sg_header_auth_user}}"
-                                    },
-                                    {
-                                        "key": "X-Shopgate-Auth-Token",
-                                        "value": "{{gen_sg_header_auth_token}}"
-                                    }
-                                ],
-                                "body": {
-                                    "mode": "formdata",
-                                    "formdata": [
-                                        {
-                                            "key": "shop_number",
-                                            "value": "{{sg_shop_number}}",
-                                            "type": "text"
-                                        },
-                                        {
-                                            "key": "action",
-                                            "value": "{{framework_action_get_items}}",
-                                            "type": "text"
-                                        },
-                                        {
-                                            "key": "limit",
-                                            "value": "5",
-                                            "type": "text"
-                                        },
-                                        {
-                                            "key": "offset",
-                                            "value": "0",
-                                            "type": "text"
-                                        }
-                                    ]
-                                },
-                                "url": {
-                                    "raw": "{{sg_endpoint_api}}/getItems",
-                                    "host": [
-                                        "{{sg_endpoint_api}}"
-                                    ],
-                                    "path": [
-                                        "getItems"
-                                    ]
-                                }
-                            },
-                            "response": []
-                        },
-                        {
-                            "name": "SG: get cats normally",
-                            "event": [
-                                {
-                                    "listen": "test",
-                                    "script": {
-                                        "exec": [
-                                            "pm.test(\"Status code is 200\", function () {",
-                                            "    pm.response.to.have.status(200);",
-                                            "});",
-                                            "",
-                                            "pm.test(\"Not an error\", function () {",
-                                            "    pm.response.to.not.have.jsonBody('error');",
-                                            "});",
-                                            "",
-                                            "var jsonObject = xml2Json(responseBody);",
-                                            "pm.test(\"Check that categories are normally exporting\", function () {",
-                                            "    pm.expect(jsonObject.items.category).to.be.lengthOf(5);",
-                                            "});"
-                                        ],
-                                        "type": "text/javascript"
-                                    }
-                                }
-                            ],
-                            "request": {
-                                "method": "POST",
-                                "header": [
-                                    {
-                                        "key": "Accept",
-                                        "value": "*/*"
-                                    },
-                                    {
-                                        "key": "X-Shopgate-Auth-User",
-                                        "value": "{{gen_sg_header_auth_user}}"
-                                    },
-                                    {
-                                        "key": "X-Shopgate-Auth-Token",
-                                        "value": "{{gen_sg_header_auth_token}}"
-                                    }
-                                ],
-                                "body": {
-                                    "mode": "formdata",
-                                    "formdata": [
-                                        {
-                                            "key": "shop_number",
-                                            "value": "{{sg_shop_number}}",
-                                            "type": "text"
-                                        },
-                                        {
-                                            "key": "action",
-                                            "value": "{{framework_action_get_items}}",
-                                            "type": "text"
-                                        },
-                                        {
-                                            "key": "limit",
-                                            "value": "5",
-                                            "type": "text"
-                                        },
-                                        {
-                                            "key": "offset",
-                                            "value": "0",
-                                            "type": "text"
-                                        }
-                                    ]
-                                },
-                                "url": {
-                                    "raw": "{{sg_endpoint_api}}/getCategories",
-                                    "host": [
-                                        "{{sg_endpoint_api}}"
-                                    ],
-                                    "path": [
-                                        "getCategories"
-                                    ]
-                                }
-                            },
-                            "response": []
-                        },
-                        {
-                            "name": "SG: enable cat export",
-                            "event": [
-                                {
-                                    "listen": "test",
-                                    "script": {
-                                        "exec": [
-                                            "pm.test(\"Status code is 200\", function () {",
-                                            "    pm.response.to.have.status(200);",
-                                            "});",
-                                            "",
-                                            "pm.test(\"enable inactive product export\", function () {",
-                                            "    var jsonData = pm.response.json();",
-                                            "    pm.expect(jsonData.shopgate_settings).lengthOf(1);",
-                                            "    pm.expect(jsonData.shopgate_settings[0].old).to.eq(\"1\");",
-                                            "    pm.expect(jsonData.shopgate_settings[0].new).to.eq(\"0\");",
-                                            "});"
-                                        ],
-                                        "type": "text/javascript"
-                                    }
-                                }
-                            ],
-                            "request": {
-                                "method": "POST",
-                                "header": [
-                                    {
-                                        "key": "X-Shopgate-Auth-User",
-                                        "value": "{{gen_sg_header_auth_user}}"
-                                    },
-                                    {
-                                        "key": "X-Shopgate-Auth-Token",
-                                        "value": "{{gen_sg_header_auth_token}}"
-                                    }
-                                ],
-                                "body": {
-                                    "mode": "formdata",
-                                    "formdata": [
-                                        {
-                                            "key": "shop_number",
-                                            "value": "{{sg_shop_number}}",
-                                            "type": "text"
-                                        },
-                                        {
-                                            "key": "action",
-                                            "value": "{{framework_action_set_settings}}",
-                                            "type": "text"
-                                        },
-                                        {
-                                            "key": "shopgate_settings[0][name]",
-                                            "value": "skip_category_assignment",
-                                            "type": "text"
-                                        },
-                                        {
-                                            "key": "shopgate_settings[0][value]",
-                                            "value": "0",
-                                            "type": "text"
-                                        }
-                                    ]
-                                },
-                                "url": {
-                                    "raw": "{{sg_endpoint_api}}/setSettings",
-                                    "host": [
-                                        "{{sg_endpoint_api}}"
-                                    ],
-                                    "path": [
-                                        "setSettings"
-                                    ]
-                                }
-                            },
-                            "response": []
-                        },
-                        {
-                            "name": "SG: is normal export",
-                            "event": [
-                                {
-                                    "listen": "test",
-                                    "script": {
-                                        "exec": [
-                                            "pm.test(\"Status code is 200\", function () {",
-                                            "    pm.response.to.have.status(200);",
-                                            "});",
-                                            "",
-                                            "pm.test(\"Not an error\", function () {",
-                                            "    pm.response.to.not.have.jsonBody('error');",
-                                            "});",
-                                            "",
-                                            "var jsonObject = xml2Json(responseBody);",
-                                            "pm.test(\"Check products have categories exported\", function () {",
-                                            "    console.log(jsonObject)",
-                                            "    jsonObject.items.item.forEach(item => {",
-                                            "        pm.expect(item.categories.category).to.not.be.undefined;",
-                                            "    });",
-                                            "});"
-                                        ],
-                                        "type": "text/javascript"
-                                    }
-                                }
-                            ],
-                            "request": {
-                                "method": "POST",
-                                "header": [
-                                    {
-                                        "key": "Accept",
-                                        "value": "*/*"
-                                    },
-                                    {
-                                        "key": "X-Shopgate-Auth-User",
-                                        "value": "{{gen_sg_header_auth_user}}"
-                                    },
-                                    {
-                                        "key": "X-Shopgate-Auth-Token",
-                                        "value": "{{gen_sg_header_auth_token}}"
-                                    }
-                                ],
-                                "body": {
-                                    "mode": "formdata",
-                                    "formdata": [
-                                        {
-                                            "key": "shop_number",
-                                            "value": "{{sg_shop_number}}",
-                                            "type": "text"
-                                        },
-                                        {
-                                            "key": "action",
-                                            "value": "{{framework_action_get_items}}",
-                                            "type": "text"
-                                        },
-                                        {
-                                            "key": "limit",
-                                            "value": "5",
-                                            "type": "text"
-                                        },
-                                        {
-                                            "key": "offset",
-                                            "value": "0",
-                                            "type": "text"
-                                        }
-                                    ]
-                                },
-                                "url": {
-                                    "raw": "{{sg_endpoint_api}}/getItems",
-                                    "host": [
-                                        "{{sg_endpoint_api}}"
-                                    ],
-                                    "path": [
-                                        "getItems"
-                                    ]
-                                }
-                            },
-                            "response": []
-                        }
-                    ],
-                    "description": "For merchants with expensive exports we allow to export products without categories. This should increase performance. Internal ref. SG-184."
-                },
-                {
-                    "name": "Check Prices (grps)",
-                    "item": [
-                        {
-                            "name": "SG: disable adv price export",
-                            "event": [
-                                {
-                                    "listen": "test",
-                                    "script": {
-                                        "exec": [
-                                            "pm.test(\"Status code is 200\", function () {",
-                                            "    pm.response.to.have.status(200);",
-                                            "});",
-                                            "",
-                                            "pm.test(\"enable setting\", function () {",
-                                            "    var jsonData = pm.response.json();",
-                                            "    pm.expect(jsonData.shopgate_settings).lengthOf(1);",
-                                            "    pm.expect(jsonData.shopgate_settings[0].old).to.eq(\"0\");",
-                                            "    pm.expect(jsonData.shopgate_settings[0].new).to.eq(\"1\");",
-                                            "});"
-                                        ],
-                                        "type": "text/javascript"
-                                    }
-                                }
-                            ],
-                            "request": {
-                                "method": "POST",
-                                "header": [
-                                    {
-                                        "key": "X-Shopgate-Auth-User",
-                                        "value": "{{gen_sg_header_auth_user}}"
-                                    },
-                                    {
-                                        "key": "X-Shopgate-Auth-Token",
-                                        "value": "{{gen_sg_header_auth_token}}"
-                                    }
-                                ],
-                                "body": {
-                                    "mode": "formdata",
-                                    "formdata": [
-                                        {
-                                            "key": "shop_number",
-                                            "value": "{{sg_shop_number}}",
-                                            "type": "text"
-                                        },
-                                        {
-                                            "key": "action",
-                                            "value": "{{framework_action_set_settings}}",
-                                            "type": "text"
-                                        },
-                                        {
-                                            "key": "shopgate_settings[0][name]",
-                                            "value": "skip_advanced_price_export",
-                                            "type": "text"
-                                        },
-                                        {
-                                            "key": "shopgate_settings[0][value]",
-                                            "value": "1",
-                                            "type": "text"
-                                        }
-                                    ]
-                                },
-                                "url": {
-                                    "raw": "{{sg_endpoint_api}}/setSettings",
-                                    "host": [
-                                        "{{sg_endpoint_api}}"
-                                    ],
-                                    "path": [
-                                        "setSettings"
-                                    ]
-                                }
-                            },
-                            "response": []
-                        },
-                        {
-                            "name": "SG: check no price export",
-                            "event": [
-                                {
-                                    "listen": "test",
-                                    "script": {
-                                        "exec": [
-                                            "pm.test(\"Status code is 200\", function () {",
-                                            "    pm.response.to.have.status(200);",
-                                            "});",
-                                            "",
-                                            "pm.test(\"Not an error\", function () {",
-                                            "    pm.response.to.not.have.jsonBody('error');",
-                                            "});",
-                                            "",
-                                            "var jsonObject = xml2Json(responseBody);",
-                                            "pm.test(\"Check products have categories exported\", () => {",
-                                            "    pm.expect(jsonObject.items.item.prices).to.not.be.undefined;",
-                                            "    const price = jsonObject.items.item.prices;",
-                                            "    pm.expect(price.price).to.eq('500');",
-                                            "    pm.expect(price.sale_price).to.eq('400');",
-                                            "    pm.expect(price.base_price).to.contain('200');",
-                                            "    pm.expect(price.price).to.eq('500');",
-                                            "});",
-                                            "",
-                                            "pm.test(\"Check tier prices\", () => {",
-                                            "    pm.expect(jsonObject.items.item.prices.tier_prices).to.be.undefined;",
-                                            "});",
-                                            "",
-                                            "function checkGrp(tier, discount, min, type, customerGrpId) {",
-                                            "    pm.expect(tier._, 'incorrect discount').to.eq(discount);",
-                                            "    pm.expect(tier.$.threshold, 'incorrect threshold').to.eq(min);",
-                                            "    pm.expect(tier.$.type, 'icnorrect type').to.eq(type);",
-                                            "    if (customerGrpId) {",
-                                            "        pm.expect(tier.$.customer_group_uid, 'incorrect customer grp').to.eq(customerGrpId);",
-                                            "    }",
-                                            "}",
-                                            "function checkFixedDiscount(tier, discount, min, type, max) {",
-                                            "    checkGrp(tier, discount, min, type, null);",
-                                            "    pm.expect(tier.$.max_quantity, 'incorrect max').to.eq(max);",
-                                            "}"
-                                        ],
-                                        "type": "text/javascript"
-                                    }
-                                }
-                            ],
-                            "request": {
-                                "method": "POST",
-                                "header": [
-                                    {
-                                        "key": "Accept",
-                                        "value": "*/*"
-                                    },
-                                    {
-                                        "key": "X-Shopgate-Auth-User",
-                                        "value": "{{gen_sg_header_auth_user}}"
-                                    },
-                                    {
-                                        "key": "X-Shopgate-Auth-Token",
-                                        "value": "{{gen_sg_header_auth_token}}"
-                                    }
-                                ],
-                                "body": {
-                                    "mode": "formdata",
-                                    "formdata": [
-                                        {
-                                            "key": "shop_number",
-                                            "value": "{{sg_shop_number}}",
-                                            "type": "text"
-                                        },
-                                        {
-                                            "key": "action",
-                                            "value": "{{framework_action_get_items}}",
-                                            "type": "text"
-                                        },
-                                        {
-                                            "key": "limit",
-                                            "value": "5",
-                                            "type": "text"
-                                        },
-                                        {
-                                            "key": "offset",
-                                            "value": "0",
-                                            "type": "text"
-                                        },
-                                        {
-                                            "key": "uids[]",
-                                            "value": "{{created_product2_id}}",
-                                            "type": "text"
-                                        }
-                                    ]
-                                },
-                                "url": {
-                                    "raw": "{{sg_endpoint_api}}/getItems",
-                                    "host": [
-                                        "{{sg_endpoint_api}}"
-                                    ],
-                                    "path": [
-                                        "getItems"
-                                    ]
-                                }
-                            },
-                            "response": []
-                        },
-                        {
-                            "name": "SG: enable adv price export",
-                            "event": [
-                                {
-                                    "listen": "test",
-                                    "script": {
-                                        "exec": [
-                                            "pm.test(\"Status code is 200\", function () {",
-                                            "    pm.response.to.have.status(200);",
-                                            "});",
-                                            "",
-                                            "pm.test(\"disable setting\", function () {",
-                                            "    var jsonData = pm.response.json();",
-                                            "    pm.expect(jsonData.shopgate_settings).lengthOf(1);",
-                                            "    pm.expect(jsonData.shopgate_settings[0].old).to.eq(\"1\");",
-                                            "    pm.expect(jsonData.shopgate_settings[0].new).to.eq(\"0\");",
-                                            "});"
-                                        ],
-                                        "type": "text/javascript"
-                                    }
-                                }
-                            ],
-                            "request": {
-                                "method": "POST",
-                                "header": [
-                                    {
-                                        "key": "X-Shopgate-Auth-User",
-                                        "value": "{{gen_sg_header_auth_user}}"
-                                    },
-                                    {
-                                        "key": "X-Shopgate-Auth-Token",
-                                        "value": "{{gen_sg_header_auth_token}}"
-                                    }
-                                ],
-                                "body": {
-                                    "mode": "formdata",
-                                    "formdata": [
-                                        {
-                                            "key": "shop_number",
-                                            "value": "{{sg_shop_number}}",
-                                            "type": "text"
-                                        },
-                                        {
-                                            "key": "action",
-                                            "value": "{{framework_action_set_settings}}",
-                                            "type": "text"
-                                        },
-                                        {
-                                            "key": "shopgate_settings[0][name]",
-                                            "value": "skip_advanced_price_export",
-                                            "type": "text"
-                                        },
-                                        {
-                                            "key": "shopgate_settings[0][value]",
-                                            "value": "0",
-                                            "type": "text"
-                                        }
-                                    ]
-                                },
-                                "url": {
-                                    "raw": "{{sg_endpoint_api}}/setSettings",
-                                    "host": [
-                                        "{{sg_endpoint_api}}"
-                                    ],
-                                    "path": [
-                                        "setSettings"
-                                    ]
-                                }
-                            },
-                            "response": []
-                        },
-                        {
-                            "name": "SG: check prices",
-                            "event": [
-                                {
-                                    "listen": "test",
-                                    "script": {
-                                        "exec": [
-                                            "pm.test(\"Status code is 200\", function () {",
-                                            "    pm.response.to.have.status(200);",
-                                            "});",
-                                            "",
-                                            "pm.test(\"Not an error\", function () {",
-                                            "    pm.response.to.not.have.jsonBody('error');",
-                                            "});",
-                                            "",
-                                            "var jsonObject = xml2Json(responseBody);",
-                                            "pm.test(\"Check products have categories exported\", () => {",
-                                            "    pm.expect(jsonObject.items.item.prices).to.not.be.undefined;",
-                                            "    const price = jsonObject.items.item.prices;",
-                                            "    pm.expect(price.price).to.eq('500');",
-                                            "    pm.expect(price.sale_price).to.eq('400');",
-                                            "    pm.expect(price.base_price).to.contain('200');",
-                                            "    pm.expect(price.price).to.eq('500');",
-                                            "});",
-                                            "",
-                                            "pm.test(\"Check tier prices\", () => {",
-                                            "    pm.expect(jsonObject.items.item.prices.tier_prices.tier_price).to.not.be.undefined;",
-                                            "    const tiers = jsonObject.items.item.prices.tier_prices.tier_price;",
-                                            "    checkGrp(tiers[0], '10', '5', 'percent', '1');",
-                                            "    checkGrp(tiers[1], '20', '10', 'percent', '1');",
-                                            "    checkGrp(tiers[2], '50', '15', 'percent', '1');",
-                                            "    checkFixedDiscount(tiers[3], '200', '2', 'fixed', '3');",
-                                            "});",
-                                            "",
-                                            "function checkGrp(tier, discount, min, type, customerGrpId) {",
-                                            "    pm.expect(tier._, 'incorrect discount').to.eq(discount);",
-                                            "    pm.expect(tier.$.threshold, 'incorrect threshold').to.eq(min);",
-                                            "    pm.expect(tier.$.type, 'icnorrect type').to.eq(type);",
-                                            "    if (customerGrpId) {",
-                                            "        pm.expect(tier.$.customer_group_uid, 'incorrect customer grp').to.eq(customerGrpId);",
-                                            "    }",
-                                            "}",
-                                            "function checkFixedDiscount(tier, discount, min, type, max) {",
-                                            "    checkGrp(tier, discount, min, type, null);",
-                                            "    pm.expect(tier.$.max_quantity, 'incorrect max').to.eq(max);",
-                                            "}"
-                                        ],
-                                        "type": "text/javascript"
-                                    }
-                                }
-                            ],
-                            "request": {
-                                "method": "POST",
-                                "header": [
-                                    {
-                                        "key": "Accept",
-                                        "value": "*/*"
-                                    },
-                                    {
-                                        "key": "X-Shopgate-Auth-User",
-                                        "value": "{{gen_sg_header_auth_user}}"
-                                    },
-                                    {
-                                        "key": "X-Shopgate-Auth-Token",
-                                        "value": "{{gen_sg_header_auth_token}}"
-                                    }
-                                ],
-                                "body": {
-                                    "mode": "formdata",
-                                    "formdata": [
-                                        {
-                                            "key": "shop_number",
-                                            "value": "{{sg_shop_number}}",
-                                            "type": "text"
-                                        },
-                                        {
-                                            "key": "action",
-                                            "value": "{{framework_action_get_items}}",
-                                            "type": "text"
-                                        },
-                                        {
-                                            "key": "limit",
-                                            "value": "5",
-                                            "type": "text"
-                                        },
-                                        {
-                                            "key": "offset",
-                                            "value": "0",
-                                            "type": "text"
-                                        },
-                                        {
-                                            "key": "uids[]",
-                                            "value": "{{created_product2_id}}",
-                                            "type": "text"
-                                        }
-                                    ]
-                                },
-                                "url": {
-                                    "raw": "{{sg_endpoint_api}}/getItems",
-                                    "host": [
-                                        "{{sg_endpoint_api}}"
-                                    ],
-                                    "path": [
-                                        "getItems"
-                                    ]
-                                }
-                            },
-                            "response": []
-                        }
-                    ]
-                }
-            ],
-            "description": "Catalog export related tests"
-        },
-        {
-            "name": "Deactivate shop test",
-            "item": [
-                {
-                    "name": "SG: try deactivate store",
-                    "event": [
-                        {
-                            "listen": "test",
-                            "script": {
-                                "exec": [
-                                    "pm.test(\"Status code is 200\", function () {",
-                                    "    pm.response.to.have.status(200);",
-                                    "});",
-                                    "",
-                                    "pm.test(\"de-activation via plugin is not implemented\", function () {",
-                                    "    var jsonData = pm.response.json();",
-                                    "    pm.expect(jsonData.shopgate_settings).lengthOf(1);",
-                                    "    pm.expect(jsonData.shopgate_settings[0].old).to.eq(false);",
-                                    "});"
-                                ],
-                                "type": "text/javascript"
-                            }
-                        }
-                    ],
-                    "request": {
-                        "method": "POST",
-                        "header": [
-                            {
-                                "key": "X-Shopgate-Auth-User",
-                                "value": "{{gen_sg_header_auth_user}}"
-                            },
-                            {
-                                "key": "X-Shopgate-Auth-Token",
-                                "value": "{{gen_sg_header_auth_token}}"
-                            }
-                        ],
-                        "body": {
-                            "mode": "formdata",
-                            "formdata": [
-                                {
-                                    "key": "shop_number",
-                                    "value": "{{sg_shop_number}}",
-                                    "type": "text"
-                                },
-                                {
-                                    "key": "action",
-                                    "value": "{{framework_action_set_settings}}",
-                                    "type": "text"
-                                },
-                                {
-                                    "key": "shopgate_settings[0][name]",
-                                    "value": "shop_is_active",
-                                    "type": "text"
-                                },
-                                {
-                                    "key": "shopgate_settings[0][value]",
-                                    "value": "0",
-                                    "type": "text"
-                                }
-                            ]
-                        },
-                        "url": {
-                            "raw": "{{sg_endpoint_api}}/setSettings",
-                            "host": [
-                                "{{sg_endpoint_api}}"
-                            ],
-                            "path": [
-                                "setSettings"
-                            ]
-                        }
-                    },
-                    "response": []
-                },
-                {
-                    "name": "SW: config cache clear",
-                    "event": [
-                        {
-                            "listen": "test",
-                            "script": {
-                                "exec": [
-                                    "pm.test(\"Status code is 200\", function () {\r",
-                                    "    pm.response.to.have.status(200);\r",
-                                    "});"
-                                ],
-                                "type": "text/javascript"
-                            }
-                        }
-                    ],
-                    "request": {
-                        "method": "DELETE",
-                        "header": [],
-                        "url": {
-                            "raw": "{{sw_endpoint_api}}/caches/config",
-                            "host": [
-                                "{{sw_endpoint_api}}"
-                            ],
-                            "path": [
-                                "caches",
-                                "config"
-                            ]
-                        }
-                    },
-                    "response": []
-                },
-                {
-                    "name": "SG: ping",
-                    "event": [
-                        {
-                            "listen": "test",
-                            "script": {
-                                "exec": [
-                                    "pm.test(\"Status code is 200\", function () {",
-                                    "    pm.response.to.have.status(200);",
-                                    "});",
-                                    "",
-                                    "pm.test(\"Ping works\", function () {",
-                                    "    var jsonData = pm.response.json();",
-                                    "    pm.expect(jsonData.pong).to.eq('OK');",
-                                    "});"
-                                ],
-                                "type": "text/javascript"
-                            }
-                        }
-                    ],
-                    "request": {
-                        "method": "POST",
-                        "header": [
-                            {
-                                "key": "X-Shopgate-Auth-User",
-                                "value": "{{gen_sg_header_auth_user}}"
-                            },
-                            {
-                                "key": "X-Shopgate-Auth-Token",
-                                "value": "{{gen_sg_header_auth_token}}"
-                            }
-                        ],
-                        "body": {
-                            "mode": "formdata",
-                            "formdata": [
-                                {
-                                    "key": "shop_number",
-                                    "value": "{{sg_shop_number}}",
-                                    "type": "text"
-                                },
-                                {
-                                    "key": "action",
-                                    "value": "{{framework_action_set_settings}}",
-                                    "type": "text"
-                                },
-                                {
-                                    "key": "shopgate_settings[0][name]",
-                                    "value": "shop_is_active",
-                                    "type": "text"
-                                },
-                                {
-                                    "key": "shopgate_settings[0][value]",
-                                    "value": "0",
-                                    "type": "text"
-                                }
-                            ]
-                        },
-                        "url": {
-                            "raw": "{{sg_endpoint_api}}/ping",
-                            "host": [
-                                "{{sg_endpoint_api}}"
-                            ],
-                            "path": [
-                                "ping"
-                            ]
-                        }
-                    },
-                    "response": []
-                }
-            ],
-            "description": "SG runs a deactivation script after every import, so we need to make sure the store does not get deactivated by it\n\n```\n[shopgate_settings] => Array\n       (\n            [0] => Array\n                (\n                    [name] => shop_is_active\n                    [value] => 0\n                )\n\n        )\n\n\n```\n\nStartFragment"
-        },
-        {
-            "name": "Cleanup",
-            "item": [
-                {
-                    "name": "SW: remove prod 1",
-                    "event": [
-                        {
-                            "listen": "test",
-                            "script": {
-                                "exec": [
-                                    "pm.test(\"Status code is 200\", function () {\r",
-                                    "    pm.response.to.have.status(200);\r",
-                                    "});\r",
-                                    "\r",
-                                    "pm.test(\"Check success\", function () {\r",
-                                    "    var jsonData = pm.response.json();\r",
-                                    "    pm.expect(jsonData.success).to.eq(true);\r",
-                                    "});"
-                                ],
-                                "type": "text/javascript"
-                            }
-                        }
-                    ],
-                    "request": {
-                        "method": "DELETE",
-                        "header": [],
-                        "url": {
-                            "raw": "{{sw_endpoint_api}}/articles/:articleId",
-                            "host": [
-                                "{{sw_endpoint_api}}"
-                            ],
-                            "path": [
-                                "articles",
-                                ":articleId"
-                            ],
-                            "variable": [
-                                {
-                                    "key": "articleId",
-                                    "value": "{{created_product1_id}}"
-                                }
-                            ]
-                        }
-                    },
-                    "response": []
-                },
-                {
-                    "name": "SW: remove prod 2",
-                    "event": [
-                        {
-                            "listen": "test",
-                            "script": {
-                                "exec": [
-                                    "pm.test(\"Status code is 200\", function () {\r",
-                                    "    pm.response.to.have.status(200);\r",
-                                    "});\r",
-                                    "\r",
-                                    "pm.test(\"Check success\", function () {\r",
-                                    "    var jsonData = pm.response.json();\r",
-                                    "    pm.expect(jsonData.success).to.eq(true);\r",
-                                    "});"
-                                ],
-                                "type": "text/javascript"
-                            }
-                        }
-                    ],
-                    "request": {
-                        "method": "DELETE",
-                        "header": [],
-                        "url": {
-                            "raw": "{{sw_endpoint_api}}/articles/:articleId",
-                            "host": [
-                                "{{sw_endpoint_api}}"
-                            ],
-                            "path": [
-                                "articles",
-                                ":articleId"
-                            ],
-                            "variable": [
-                                {
-                                    "key": "articleId",
-                                    "value": "{{created_product2_id}}"
-                                }
-                            ]
-                        }
-                    },
-                    "response": []
-                }
-            ]
-        },
-        {
-            "name": "WebCheckout",
-            "item": [
-                {
-                    "name": "SW: Get customer 1",
-                    "event": [
-                        {
-                            "listen": "prerequest",
-                            "script": {
-                                "exec": [
-                                    "// allowCookie=1\r",
-                                    "const jar = pm.cookies.jar();\r",
-                                    "jar.set(pm.environment.get(\"host\"), 'allowCookie', '1');"
-                                ],
-                                "type": "text/javascript"
-                            }
-                        },
-                        {
-                            "listen": "test",
-                            "script": {
-                                "exec": [
-                                    "pm.test(\"Status code is 200\", function () {",
-                                    "    pm.response.to.have.status(200);",
-                                    "});",
-                                    "",
-                                    "pm.test(\"get customer data\", function () {",
-                                    "    var jsonData = pm.response.json();",
-                                    "    pm.expect(jsonData.data).to.not.be.undefined;",
-                                    "    pm.expect(jsonData.data.number).to.not.be.undefined;",
-                                    "    pm.environment.set('gen_customer_1_num', jsonData.data.number);",
-                                    "});"
-                                ],
-                                "type": "text/javascript"
-                            }
-                        }
-                    ],
-                    "request": {
-                        "method": "GET",
-                        "header": [],
-                        "url": {
-                            "raw": "{{sw_endpoint_api}}/customers/1",
-                            "host": [
-                                "{{sw_endpoint_api}}"
-                            ],
-                            "path": [
-                                "customers",
-                                "1"
-                            ]
-                        }
-                    },
-                    "response": []
-                },
-                {
-                    "name": "SG: login customer",
-                    "event": [
-                        {
-                            "listen": "test",
-                            "script": {
-                                "exec": [
-                                    "// Load the HTML response to $",
-                                    "const $ = cheerio.load(pm.response.text());",
-                                    "pm.test(\"Check that customer got logged in\", function () {",
-                                    "    const greeting = $('.account--display-greeting');",
-                                    "    pm.expect(greeting).to.be.not.undefined;",
-                                    "    pm.expect(greeting.text()).to.contain('Max');",
-                                    "});",
-                                    "",
-                                    "// Allow cookie deletion by going to cookies -> Domain Allowlist",
-                                    "const jar = pm.cookies.jar();",
-                                    "jar.unset(pm.environment.get(\"host\"), 'session-1', (error) => error && console.log(error.message));",
-                                    "jar.unset(pm.environment.get(\"host\"), 'slt', (error) => error && console.log(error.message));"
-                                ],
-                                "type": "text/javascript"
-                            }
-                        }
-                    ],
-                    "request": {
-                        "auth": {
-                            "type": "jwt",
-                            "jwt": [
-                                {
-                                    "key": "payload",
-                                    "value": "{\"customer_id\": \"{{gen_customer_1_num}}\"}",
-                                    "type": "string"
-                                },
-                                {
-                                    "key": "addTokenTo",
-                                    "value": "queryParam",
-                                    "type": "string"
-                                },
-                                {
-                                    "key": "secret",
-                                    "value": "{{sg_api_key}}",
-                                    "type": "string"
-                                },
-                                {
-                                    "key": "isSecretBase64Encoded",
-                                    "value": false,
-                                    "type": "boolean"
-                                },
-                                {
-                                    "key": "algorithm",
-                                    "value": "HS256",
-                                    "type": "string"
-                                },
-                                {
-                                    "key": "headerPrefix",
-                                    "value": "Bearer",
-                                    "type": "string"
-                                },
-                                {
-                                    "key": "queryParamKey",
-                                    "value": "token",
-                                    "type": "string"
-                                },
-                                {
-                                    "key": "header",
-                                    "value": "{}",
-                                    "type": "string"
-                                }
-                            ]
-                        },
-                        "method": "GET",
-                        "header": [
-                            {
-                                "key": "User-Agent",
-                                "value": "PostmanRuntime libshopgate",
-                                "type": "text"
-                            }
-                        ],
-                        "url": {
-                            "raw": "{{sg_endpoint_api}}/login",
-                            "host": [
-                                "{{sg_endpoint_api}}"
-                            ],
-                            "path": [
-                                "login"
-                            ]
-                        }
-                    },
-                    "response": []
-                },
-                {
-                    "name": "SG: create guest cart",
-                    "event": [
-                        {
-                            "listen": "test",
-                            "script": {
-                                "exec": [
-                                    "pm.test(\"Status code is 201\", function () {",
-                                    "    pm.response.to.have.status(201);",
-                                    "});",
-                                    "",
-                                    "pm.test(\"Get session\", function () {",
-                                    "    var jsonData = pm.response.json();",
-                                    "    pm.expect(jsonData.sessionId).to.not.be.undefined;",
-                                    "    pm.environment.set('gen_sessionId_guest', jsonData.sessionId);",
-                                    "});",
-                                    "",
-                                    "",
-                                    "// Allow cookie deletion by going to cookies -> Domain Allowlist",
-                                    "const jar = pm.cookies.jar();",
-                                    "jar.unset(pm.environment.get(\"host\"), 'session-1', (error) => error && console.log(error.message));",
-                                    "jar.unset(pm.environment.get(\"host\"), 'slt', (error) => error && console.log(error.message));"
-                                ],
-                                "type": "text/javascript"
-                            }
-                        }
-                    ],
-                    "request": {
-                        "method": "POST",
-                        "header": [
-                            {
-                                "key": "User-Agent",
-                                "value": "Shopgate PWA",
-                                "type": "text"
-                            }
-                        ],
-                        "body": {
-                            "mode": "raw",
-                            "raw": "{\n    \"articles\": [\n        {\n            \"product_id\": \"{{gen_product_main_id}}\",\n            \"variant_id\": \"\",\n            \"quantity\": 1,\n            \"options\": []\n        }\n    ],\n    \"customerId\": null\n}",
-                            "options": {
-                                "raw": {
-                                    "language": "json"
-                                }
-                            }
-                        },
-                        "url": {
-                            "raw": "{{sg_endpoint_api}}/addToCart",
-                            "host": [
-                                "{{sg_endpoint_api}}"
-                            ],
-                            "path": [
-                                "addToCart"
-                            ]
-                        }
-                    },
-                    "response": []
-                },
-                {
-                    "name": "SG: login guest",
-                    "event": [
-                        {
-                            "listen": "test",
-                            "script": {
-                                "exec": [
-                                    "// Load the HTML response to $",
-                                    "const $ = cheerio.load(pm.response.text());",
-                                    "pm.test(\"Check that guest got logged in\", function () {",
-                                    "    const productInCart = $('.content--sku.content');",
-                                    "    pm.expect(productInCart).to.be.not.undefined;",
-                                    "    pm.expect(productInCart.text()).to.contain('SW10001');",
-                                    "});",
-                                    "",
-                                    "// Allow cookie deletion by going to cookies -> Domain Allowlist",
-                                    "const jar = pm.cookies.jar();",
-                                    "jar.unset(pm.environment.get(\"host\"), 'session-1', (error) => error && console.log(error.message));",
-                                    "jar.unset(pm.environment.get(\"host\"), 'slt', (error) => error && console.log(error.message));"
-                                ],
-                                "type": "text/javascript"
-                            }
-                        }
-                    ],
-                    "request": {
-                        "method": "GET",
-                        "header": [],
-                        "url": {
-                            "raw": "{{sg_endpoint_api}}/login?sessionId={{gen_sessionId_guest}}&guest=1&redirectTo=checkout.cart",
-                            "host": [
-                                "{{sg_endpoint_api}}"
-                            ],
-                            "path": [
-                                "login"
-                            ],
-                            "query": [
-                                {
-                                    "key": "sessionId",
-                                    "value": "{{gen_sessionId_guest}}"
-                                },
-                                {
-                                    "key": "guest",
-                                    "value": "1"
-                                },
-                                {
-                                    "key": "redirectTo",
-                                    "value": "checkout.cart"
-                                }
-                            ]
-                        }
-                    },
-                    "response": []
-                },
-                {
-                    "name": "SG: login & prod page",
-                    "event": [
-                        {
-                            "listen": "test",
-                            "script": {
-                                "exec": [
-                                    "// Load the HTML response to $",
-                                    "const $ = cheerio.load(pm.response.text());",
-                                    "pm.test(\"Check that we have a sessionId being sent to App\", function () {",
-                                    "    const session = $('script:contains(\"sessionId\")');",
-                                    "    pm.expect(session).to.be.not.undefined;",
-                                    "    pm.expect(session.text()).to.contain(\"{'sessionId': '\");",
-                                    "});",
-                                    "",
-                                    "// Allow cookie deletion by going to cookies -> Domain Allowlist",
-                                    "const jar = pm.cookies.jar();",
-                                    "jar.unset(pm.environment.get(\"host\"), 'session-1', (error) => error && console.log(error.message));",
-                                    "jar.unset(pm.environment.get(\"host\"), 'slt', (error) => error && console.log(error.message));"
-                                ],
-                                "type": "text/javascript"
-                            }
-                        }
-                    ],
-                    "request": {
-                        "auth": {
-                            "type": "jwt",
-                            "jwt": [
-                                {
-                                    "key": "payload",
-                                    "value": "{\"customer_id\": \"{{gen_customer_1_num}}\"}",
-                                    "type": "string"
-                                },
-                                {
-                                    "key": "addTokenTo",
-                                    "value": "queryParam",
-                                    "type": "string"
-                                },
-                                {
-                                    "key": "secret",
-                                    "value": "{{sg_api_key}}",
-                                    "type": "string"
-                                },
-                                {
-                                    "key": "isSecretBase64Encoded",
-                                    "value": false,
-                                    "type": "boolean"
-                                },
-                                {
-                                    "key": "algorithm",
-                                    "value": "HS256",
-                                    "type": "string"
-                                },
-                                {
-                                    "key": "headerPrefix",
-                                    "value": "Bearer",
-                                    "type": "string"
-                                },
-                                {
-                                    "key": "queryParamKey",
-                                    "value": "token",
-                                    "type": "string"
-                                },
-                                {
-                                    "key": "header",
-                                    "value": "{}",
-                                    "type": "string"
-                                }
-                            ]
-                        },
-                        "method": "GET",
-                        "header": [
-                            {
-                                "key": "User-Agent",
-                                "value": "PostmanRuntime libshopgate",
-                                "type": "text"
-                            }
-                        ],
-                        "url": {
-                            "raw": "{{sg_endpoint_api}}/login?redirectTo=detail.index.sArticle.3",
-                            "host": [
-                                "{{sg_endpoint_api}}"
-                            ],
-                            "path": [
-                                "login"
-                            ],
-                            "query": [
-                                {
-                                    "key": "redirectTo",
-                                    "value": "detail.index.sArticle.3"
-                                }
-                            ]
-                        },
-                        "description": "Logs in, redirects to product page & checks that the session is being sent to the App."
-                    },
-                    "response": []
-                }
-            ]
-        }
-    ],
-    "auth": {
-        "type": "basic",
-        "basic": [
+          "name": "System",
+          "item": [
             {
-                "key": "password",
-                "value": "{{sw_api_key}}",
-                "type": "string"
+              "name": "SW: Get shop info",
+              "event": [
+                {
+                  "listen": "prerequest",
+                  "script": {
+                    "exec": [
+                      "// allowCookie=1\r",
+                      "const jar = pm.cookies.jar();\r",
+                      "jar.set(pm.environment.get(\"host\"), 'allowCookie', '1');"
+                    ],
+                    "type": "text/javascript"
+                  }
+                }
+              ],
+              "request": {
+                "method": "GET",
+                "header": [],
+                "url": {
+                  "raw": "{{sw_endpoint_api}}/shops/1",
+                  "host": [
+                    "{{sw_endpoint_api}}"
+                  ],
+                  "path": [
+                    "shops",
+                    "1"
+                  ]
+                }
+              },
+              "response": []
+            }
+          ]
+        },
+        {
+          "name": "Product",
+          "item": [
+            {
+              "name": "SW: Get main product",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {\r",
+                      "    pm.response.to.have.status(200);\r",
+                      "});\r",
+                      "\r",
+                      "pm.test(\"Get main product\", function () {\r",
+                      "    var jsonData = pm.response.json();\r",
+                      "    pm.expect(jsonData.data).to.haveOwnProperty('id').to.be.a('number');\r",
+                      "    pm.environment.set(\"gen_product_main_id\", jsonData.data.id);\r",
+                      "});"
+                    ],
+                    "type": "text/javascript"
+                  }
+                }
+              ],
+              "request": {
+                "method": "GET",
+                "header": [],
+                "url": {
+                  "raw": "{{sw_endpoint_api}}/articles/SW10001?useNumberAsId=true",
+                  "host": [
+                    "{{sw_endpoint_api}}"
+                  ],
+                  "path": [
+                    "articles",
+                    "SW10001"
+                  ],
+                  "query": [
+                    {
+                      "key": "useNumberAsId",
+                      "value": "true"
+                    }
+                  ]
+                }
+              },
+              "response": []
             },
             {
-                "key": "username",
-                "value": "demo",
-                "type": "string"
+              "name": "SW: Get main category",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {\r",
+                      "    pm.response.to.have.status(200);\r",
+                      "});\r",
+                      "\r",
+                      "pm.test(\"Get main category\", function () {\r",
+                      "    var jsonData = pm.response.json();\r",
+                      "    pm.expect(jsonData.data[0]).to.haveOwnProperty('id').to.be.a('number');\r",
+                      "    pm.environment.set(\"gen_category_main_id\", jsonData.data[0].id);\r",
+                      "});"
+                    ],
+                    "type": "text/javascript"
+                  }
+                }
+              ],
+              "protocolProfileBehavior": {
+                "disableBodyPruning": true
+              },
+              "request": {
+                "method": "GET",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\r\n    \"filter\": [\r\n        {\r\n            \"property\": \"parentId\",\r\n            \"expression\": \">\",\r\n            \"value\": \"1\"\r\n        }\r\n    ],\r\n    \"limit\": 1\r\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{sw_endpoint_api}}/categories",
+                  "host": [
+                    "{{sw_endpoint_api}}"
+                  ],
+                  "path": [
+                    "categories"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "SW: create inactive prod",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 201\", function () {\r",
+                      "    pm.response.to.have.status(201);\r",
+                      "});\r",
+                      "\r",
+                      "pm.test(\"Get id of created product\", function () {\r",
+                      "    var jsonData = pm.response.json();\r",
+                      "    pm.expect(jsonData.data.id).to.be.a(\"number\");\r",
+                      "    pm.environment.set('created_product1_id', jsonData.data.id);\r",
+                      "});"
+                    ],
+                    "type": "text/javascript"
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\r\n    \"name\": \"API: disabled product\",\r\n    \"active\": false,\r\n    \"tax\": 19,\r\n    \"supplier\": \"Sport Shoes Inc.\",\r\n    \"categories\": [\r\n        {\r\n            \"id\": {{gen_category_main_id}}\r\n        }\r\n    ],\r\n    \"mainDetail\": {\r\n        \"number\": \"API-INACTIVE\",\r\n        \"active\": true,\r\n        \"prices\": [\r\n            {\r\n                \"customerGroupKey\": \"EK\",\r\n                \"price\": 999\r\n            }\r\n        ]\r\n    }\r\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{sw_endpoint_api}}/articles",
+                  "host": [
+                    "{{sw_endpoint_api}}"
+                  ],
+                  "path": [
+                    "articles"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "SW: create price grp",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 201\", function () {\r",
+                      "    pm.response.to.have.status(201);\r",
+                      "});\r",
+                      "\r",
+                      "pm.test(\"Get id of created product\", function () {\r",
+                      "    var jsonData = pm.response.json();\r",
+                      "    pm.expect(jsonData.data.id).to.be.a(\"number\");\r",
+                      "    pm.environment.set('created_product2_id', jsonData.data.id);\r",
+                      "});"
+                    ],
+                    "type": "text/javascript"
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\r\n    \"name\": \"API: price grp product\",\r\n    \"active\": true,\r\n    \"tax\": 19,\r\n    \"supplier\": \"Active Runners LLC\",\r\n    \"categories\": [\r\n        {\r\n            \"id\": {{gen_category_main_id}}\r\n        }\r\n    ],\r\n    \"lastStock\": true, // stock cannot go into negatives (saleable)\r\n    \"priceGroupActive\": true,\r\n    \"priceGroupId\": 500,\r\n    \"mainDetail\": {\r\n        \"number\": \"API-PRICE-GRP\",\r\n        \"active\": true,\r\n        \"prices\": [\r\n            {\r\n                \"customerGroupKey\": \"EK\",\r\n                \"from\": \"1\",\r\n                \"to\": \"3\",\r\n                \"price\": 200,\r\n                \"pseudoPrice\": 250, // fake price to cross out\r\n                \"basePrice\": 90\r\n            },\r\n            {\r\n                \"customerGroupKey\": \"EK\",\r\n                \"from\": \"4\",\r\n                \"to\": \"7\",\r\n                \"price\": 100,\r\n                \"pseudoPrice\": 250,\r\n                \"basePrice\": 90\r\n            }\r\n        ],\r\n        \"inStock\": 500,\r\n        \"minPurchase\": 2,\r\n        \"maxPurchase\": 10,\r\n        \"purchaseSteps\": 2,\r\n        \"position\": 5\r\n    }\r\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{sw_endpoint_api}}/articles",
+                  "host": [
+                    "{{sw_endpoint_api}}"
+                  ],
+                  "path": [
+                    "articles"
+                  ]
+                }
+              },
+              "response": []
             }
-        ]
+          ]
+        }
+      ]
     },
-    "event": [
+    {
+      "name": "Catalog",
+      "item": [
         {
-            "listen": "prerequest",
-            "script": {
-                "type": "text/javascript",
-                "exec": [
-                    "/**",
-                    " *  SG Token generation",
-                    " */",
-                    "var tstamp = Math.floor(Date.now() / 1000);",
-                    "",
-                    "// Use the CryptoJS",
-                    "var authUser = pm.environment.get('sg_customer_number') + \"-\" + tstamp;",
-                    "var tokenData = \"SPA-\" + pm.environment.get('sg_customer_number') + \"-\" + tstamp + \"-\" + pm.environment.get('sg_api_key');",
-                    "",
-                    "var authToken = CryptoJS.SHA1(tokenData).toString();",
-                    "",
-                    "// Set the new header values",
-                    "pm.environment.set(\"gen_sg_header_auth_user\", authUser);",
-                    "pm.environment.set(\"gen_sg_header_auth_token\", authToken);"
-                ]
+          "name": "Export inactive",
+          "item": [
+            {
+              "name": "SG: try inactive export",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      "",
+                      "pm.test(\"Make sure the product is not exported as it's inactive\", function () {",
+                      "    var jsonData = pm.response.json();",
+                      "    pm.expect(jsonData.error).to.eql(82);",
+                      "});"
+                    ],
+                    "type": "text/javascript"
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "*/*"
+                  },
+                  {
+                    "key": "X-Shopgate-Auth-User",
+                    "value": "{{gen_sg_header_auth_user}}"
+                  },
+                  {
+                    "key": "X-Shopgate-Auth-Token",
+                    "value": "{{gen_sg_header_auth_token}}"
+                  }
+                ],
+                "body": {
+                  "mode": "formdata",
+                  "formdata": [
+                    {
+                      "key": "shop_number",
+                      "value": "{{sg_shop_number}}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "action",
+                      "value": "{{framework_action_get_items}}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "limit",
+                      "value": "5",
+                      "type": "text"
+                    },
+                    {
+                      "key": "offset",
+                      "value": "0",
+                      "type": "text"
+                    },
+                    {
+                      "key": "uids[]",
+                      "value": "{{created_product1_id}}",
+                      "type": "text"
+                    }
+                  ]
+                },
+                "url": {
+                  "raw": "{{sg_endpoint_api}}/getItems",
+                  "host": [
+                    "{{sg_endpoint_api}}"
+                  ],
+                  "path": [
+                    "getItems"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "SG: set export inactive",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      "",
+                      "pm.test(\"enable inactive product export\", function () {",
+                      "    var jsonData = pm.response.json();",
+                      "    pm.expect(jsonData.shopgate_settings).lengthOf(1);",
+                      "    pm.expect(jsonData.shopgate_settings[0].new).to.eq(\"1\");",
+                      "});"
+                    ],
+                    "type": "text/javascript"
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "X-Shopgate-Auth-User",
+                    "value": "{{gen_sg_header_auth_user}}"
+                  },
+                  {
+                    "key": "X-Shopgate-Auth-Token",
+                    "value": "{{gen_sg_header_auth_token}}"
+                  }
+                ],
+                "body": {
+                  "mode": "formdata",
+                  "formdata": [
+                    {
+                      "key": "shop_number",
+                      "value": "{{sg_shop_number}}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "action",
+                      "value": "{{framework_action_set_settings}}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "shopgate_settings[0][name]",
+                      "value": "export_product_inactive",
+                      "type": "text"
+                    },
+                    {
+                      "key": "shopgate_settings[0][value]",
+                      "value": "1",
+                      "type": "text"
+                    }
+                  ]
+                },
+                "url": {
+                  "raw": "{{sg_endpoint_api}}/setSettings",
+                  "host": [
+                    "{{sg_endpoint_api}}"
+                  ],
+                  "path": [
+                    "setSettings"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "SW: config cache clear",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {\r",
+                      "    pm.response.to.have.status(200);\r",
+                      "});"
+                    ],
+                    "type": "text/javascript"
+                  }
+                }
+              ],
+              "request": {
+                "method": "DELETE",
+                "header": [],
+                "url": {
+                  "raw": "{{sw_endpoint_api}}/caches/config",
+                  "host": [
+                    "{{sw_endpoint_api}}"
+                  ],
+                  "path": [
+                    "caches",
+                    "config"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "SG: try inactive export",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      "",
+                      "pm.test(\"Not an error\", function () {",
+                      "    pm.response.to.not.have.jsonBody('error');",
+                      "});",
+                      "",
+                      "pm.test(\"Check product gets exported now\", function () {",
+                      "    var jsonObject = xml2Json(responseBody);",
+                      "    pm.expect(jsonObject.items.item.$.uid).to.eql(pm.environment.get('created_product1_id').toString());",
+                      "    pm.expect(jsonObject.items.item.stock.is_saleable).to.eq('0');",
+                      "});"
+                    ],
+                    "type": "text/javascript"
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "*/*"
+                  },
+                  {
+                    "key": "X-Shopgate-Auth-User",
+                    "value": "{{gen_sg_header_auth_user}}"
+                  },
+                  {
+                    "key": "X-Shopgate-Auth-Token",
+                    "value": "{{gen_sg_header_auth_token}}"
+                  }
+                ],
+                "body": {
+                  "mode": "formdata",
+                  "formdata": [
+                    {
+                      "key": "shop_number",
+                      "value": "{{sg_shop_number}}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "action",
+                      "value": "{{framework_action_get_items}}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "limit",
+                      "value": "5",
+                      "type": "text"
+                    },
+                    {
+                      "key": "offset",
+                      "value": "0",
+                      "type": "text"
+                    },
+                    {
+                      "key": "uids[]",
+                      "value": "{{created_product1_id}}",
+                      "type": "text"
+                    }
+                  ]
+                },
+                "url": {
+                  "raw": "{{sg_endpoint_api}}/getItems",
+                  "host": [
+                    "{{sg_endpoint_api}}"
+                  ],
+                  "path": [
+                    "getItems"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "SG: unset export inactive",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      "",
+                      "pm.test(\"disable inactive product export\", function () {",
+                      "    var jsonData = pm.response.json();",
+                      "    pm.expect(jsonData.shopgate_settings).lengthOf(1);",
+                      "    pm.expect(jsonData.shopgate_settings[0].new).to.eq(\"0\");",
+                      "});"
+                    ],
+                    "type": "text/javascript"
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "X-Shopgate-Auth-User",
+                    "value": "{{gen_sg_header_auth_user}}"
+                  },
+                  {
+                    "key": "X-Shopgate-Auth-Token",
+                    "value": "{{gen_sg_header_auth_token}}"
+                  }
+                ],
+                "body": {
+                  "mode": "formdata",
+                  "formdata": [
+                    {
+                      "key": "shop_number",
+                      "value": "{{sg_shop_number}}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "action",
+                      "value": "{{framework_action_set_settings}}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "shopgate_settings[0][name]",
+                      "value": "export_product_inactive",
+                      "type": "text"
+                    },
+                    {
+                      "key": "shopgate_settings[0][value]",
+                      "value": "0",
+                      "type": "text"
+                    }
+                  ]
+                },
+                "url": {
+                  "raw": "{{sg_endpoint_api}}/setSettings",
+                  "host": [
+                    "{{sg_endpoint_api}}"
+                  ],
+                  "path": [
+                    "setSettings"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "SW: config cache clear",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {\r",
+                      "    pm.response.to.have.status(200);\r",
+                      "});"
+                    ],
+                    "type": "text/javascript"
+                  }
+                }
+              ],
+              "request": {
+                "method": "DELETE",
+                "header": [],
+                "url": {
+                  "raw": "{{sw_endpoint_api}}/caches/config",
+                  "host": [
+                    "{{sw_endpoint_api}}"
+                  ],
+                  "path": [
+                    "caches",
+                    "config"
+                  ]
+                }
+              },
+              "response": []
             }
+          ],
+          "description": "SG-145 feature request. Exporting inactive products configuration."
         },
         {
-            "listen": "test",
-            "script": {
-                "type": "text/javascript",
-                "exec": [
-                    ""
-                ]
+          "name": "Disable Cat Export",
+          "item": [
+            {
+              "name": "SG: disable cat export",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      "",
+                      "pm.test(\"enable setting\", function () {",
+                      "    var jsonData = pm.response.json();",
+                      "    pm.expect(jsonData.shopgate_settings).lengthOf(1);",
+                      "    pm.expect(jsonData.shopgate_settings[0].old).to.eq(\"0\");",
+                      "    pm.expect(jsonData.shopgate_settings[0].new).to.eq(\"1\");",
+                      "});"
+                    ],
+                    "type": "text/javascript"
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "X-Shopgate-Auth-User",
+                    "value": "{{gen_sg_header_auth_user}}"
+                  },
+                  {
+                    "key": "X-Shopgate-Auth-Token",
+                    "value": "{{gen_sg_header_auth_token}}"
+                  }
+                ],
+                "body": {
+                  "mode": "formdata",
+                  "formdata": [
+                    {
+                      "key": "shop_number",
+                      "value": "{{sg_shop_number}}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "action",
+                      "value": "{{framework_action_set_settings}}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "shopgate_settings[0][name]",
+                      "value": "skip_category_assignment",
+                      "type": "text"
+                    },
+                    {
+                      "key": "shopgate_settings[0][value]",
+                      "value": "1",
+                      "type": "text"
+                    }
+                  ]
+                },
+                "url": {
+                  "raw": "{{sg_endpoint_api}}/setSettings",
+                  "host": [
+                    "{{sg_endpoint_api}}"
+                  ],
+                  "path": [
+                    "setSettings"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "SG: get items w/o cats",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      "",
+                      "pm.test(\"Not an error\", function () {",
+                      "    pm.response.to.not.have.jsonBody('error');",
+                      "});",
+                      "",
+                      "var jsonObject = xml2Json(responseBody);",
+                      "pm.test(\"Check products have no categories exported\", function () {",
+                      "    console.log(jsonObject)",
+                      "    jsonObject.items.item.forEach(item => {",
+                      "        pm.expect(item.categories.category).to.be.undefined;",
+                      "    });",
+                      "});"
+                    ],
+                    "type": "text/javascript"
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "*/*"
+                  },
+                  {
+                    "key": "X-Shopgate-Auth-User",
+                    "value": "{{gen_sg_header_auth_user}}"
+                  },
+                  {
+                    "key": "X-Shopgate-Auth-Token",
+                    "value": "{{gen_sg_header_auth_token}}"
+                  }
+                ],
+                "body": {
+                  "mode": "formdata",
+                  "formdata": [
+                    {
+                      "key": "shop_number",
+                      "value": "{{sg_shop_number}}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "action",
+                      "value": "{{framework_action_get_items}}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "limit",
+                      "value": "5",
+                      "type": "text"
+                    },
+                    {
+                      "key": "offset",
+                      "value": "0",
+                      "type": "text"
+                    }
+                  ]
+                },
+                "url": {
+                  "raw": "{{sg_endpoint_api}}/getItems",
+                  "host": [
+                    "{{sg_endpoint_api}}"
+                  ],
+                  "path": [
+                    "getItems"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "SG: get cats normally",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      "",
+                      "pm.test(\"Not an error\", function () {",
+                      "    pm.response.to.not.have.jsonBody('error');",
+                      "});",
+                      "",
+                      "var jsonObject = xml2Json(responseBody);",
+                      "pm.test(\"Check that categories are normally exporting\", function () {",
+                      "    pm.expect(jsonObject.items.category).to.be.lengthOf(5);",
+                      "});"
+                    ],
+                    "type": "text/javascript"
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "*/*"
+                  },
+                  {
+                    "key": "X-Shopgate-Auth-User",
+                    "value": "{{gen_sg_header_auth_user}}"
+                  },
+                  {
+                    "key": "X-Shopgate-Auth-Token",
+                    "value": "{{gen_sg_header_auth_token}}"
+                  }
+                ],
+                "body": {
+                  "mode": "formdata",
+                  "formdata": [
+                    {
+                      "key": "shop_number",
+                      "value": "{{sg_shop_number}}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "action",
+                      "value": "{{framework_action_get_items}}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "limit",
+                      "value": "5",
+                      "type": "text"
+                    },
+                    {
+                      "key": "offset",
+                      "value": "0",
+                      "type": "text"
+                    }
+                  ]
+                },
+                "url": {
+                  "raw": "{{sg_endpoint_api}}/getCategories",
+                  "host": [
+                    "{{sg_endpoint_api}}"
+                  ],
+                  "path": [
+                    "getCategories"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "SG: enable cat export",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      "",
+                      "pm.test(\"enable inactive product export\", function () {",
+                      "    var jsonData = pm.response.json();",
+                      "    pm.expect(jsonData.shopgate_settings).lengthOf(1);",
+                      "    pm.expect(jsonData.shopgate_settings[0].old).to.eq(\"1\");",
+                      "    pm.expect(jsonData.shopgate_settings[0].new).to.eq(\"0\");",
+                      "});"
+                    ],
+                    "type": "text/javascript"
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "X-Shopgate-Auth-User",
+                    "value": "{{gen_sg_header_auth_user}}"
+                  },
+                  {
+                    "key": "X-Shopgate-Auth-Token",
+                    "value": "{{gen_sg_header_auth_token}}"
+                  }
+                ],
+                "body": {
+                  "mode": "formdata",
+                  "formdata": [
+                    {
+                      "key": "shop_number",
+                      "value": "{{sg_shop_number}}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "action",
+                      "value": "{{framework_action_set_settings}}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "shopgate_settings[0][name]",
+                      "value": "skip_category_assignment",
+                      "type": "text"
+                    },
+                    {
+                      "key": "shopgate_settings[0][value]",
+                      "value": "0",
+                      "type": "text"
+                    }
+                  ]
+                },
+                "url": {
+                  "raw": "{{sg_endpoint_api}}/setSettings",
+                  "host": [
+                    "{{sg_endpoint_api}}"
+                  ],
+                  "path": [
+                    "setSettings"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "SG: is normal export",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      "",
+                      "pm.test(\"Not an error\", function () {",
+                      "    pm.response.to.not.have.jsonBody('error');",
+                      "});",
+                      "",
+                      "var jsonObject = xml2Json(responseBody);",
+                      "pm.test(\"Check products have categories exported\", function () {",
+                      "    console.log(jsonObject)",
+                      "    jsonObject.items.item.forEach(item => {",
+                      "        pm.expect(item.categories.category).to.not.be.undefined;",
+                      "    });",
+                      "});"
+                    ],
+                    "type": "text/javascript"
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "*/*"
+                  },
+                  {
+                    "key": "X-Shopgate-Auth-User",
+                    "value": "{{gen_sg_header_auth_user}}"
+                  },
+                  {
+                    "key": "X-Shopgate-Auth-Token",
+                    "value": "{{gen_sg_header_auth_token}}"
+                  }
+                ],
+                "body": {
+                  "mode": "formdata",
+                  "formdata": [
+                    {
+                      "key": "shop_number",
+                      "value": "{{sg_shop_number}}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "action",
+                      "value": "{{framework_action_get_items}}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "limit",
+                      "value": "5",
+                      "type": "text"
+                    },
+                    {
+                      "key": "offset",
+                      "value": "0",
+                      "type": "text"
+                    }
+                  ]
+                },
+                "url": {
+                  "raw": "{{sg_endpoint_api}}/getItems",
+                  "host": [
+                    "{{sg_endpoint_api}}"
+                  ],
+                  "path": [
+                    "getItems"
+                  ]
+                }
+              },
+              "response": []
             }
+          ],
+          "description": "For merchants with expensive exports we allow to export products without categories. This should increase performance. Internal ref. SG-184."
+        },
+        {
+          "name": "Check Prices (grps)",
+          "item": [
+            {
+              "name": "SG: disable adv price export",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      "",
+                      "pm.test(\"enable setting\", function () {",
+                      "    var jsonData = pm.response.json();",
+                      "    pm.expect(jsonData.shopgate_settings).lengthOf(1);",
+                      "    pm.expect(jsonData.shopgate_settings[0].old).to.eq(\"0\");",
+                      "    pm.expect(jsonData.shopgate_settings[0].new).to.eq(\"1\");",
+                      "});"
+                    ],
+                    "type": "text/javascript"
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "X-Shopgate-Auth-User",
+                    "value": "{{gen_sg_header_auth_user}}"
+                  },
+                  {
+                    "key": "X-Shopgate-Auth-Token",
+                    "value": "{{gen_sg_header_auth_token}}"
+                  }
+                ],
+                "body": {
+                  "mode": "formdata",
+                  "formdata": [
+                    {
+                      "key": "shop_number",
+                      "value": "{{sg_shop_number}}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "action",
+                      "value": "{{framework_action_set_settings}}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "shopgate_settings[0][name]",
+                      "value": "skip_advanced_price_export",
+                      "type": "text"
+                    },
+                    {
+                      "key": "shopgate_settings[0][value]",
+                      "value": "1",
+                      "type": "text"
+                    }
+                  ]
+                },
+                "url": {
+                  "raw": "{{sg_endpoint_api}}/setSettings",
+                  "host": [
+                    "{{sg_endpoint_api}}"
+                  ],
+                  "path": [
+                    "setSettings"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "SG: check no price export",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      "",
+                      "pm.test(\"Not an error\", function () {",
+                      "    pm.response.to.not.have.jsonBody('error');",
+                      "});",
+                      "",
+                      "var jsonObject = xml2Json(responseBody);",
+                      "pm.test(\"Check products have categories exported\", () => {",
+                      "    pm.expect(jsonObject.items.item.prices).to.not.be.undefined;",
+                      "    const price = jsonObject.items.item.prices;",
+                      "    pm.expect(price.price).to.eq('500');",
+                      "    pm.expect(price.sale_price).to.eq('400');",
+                      "    pm.expect(price.base_price).to.contain('200');",
+                      "    pm.expect(price.price).to.eq('500');",
+                      "});",
+                      "",
+                      "pm.test(\"Check tier prices\", () => {",
+                      "    pm.expect(jsonObject.items.item.prices.tier_prices).to.be.undefined;",
+                      "});",
+                      "",
+                      "function checkGrp(tier, discount, min, type, customerGrpId) {",
+                      "    pm.expect(tier._, 'incorrect discount').to.eq(discount);",
+                      "    pm.expect(tier.$.threshold, 'incorrect threshold').to.eq(min);",
+                      "    pm.expect(tier.$.type, 'icnorrect type').to.eq(type);",
+                      "    if (customerGrpId) {",
+                      "        pm.expect(tier.$.customer_group_uid, 'incorrect customer grp').to.eq(customerGrpId);",
+                      "    }",
+                      "}",
+                      "function checkFixedDiscount(tier, discount, min, type, max) {",
+                      "    checkGrp(tier, discount, min, type, null);",
+                      "    pm.expect(tier.$.max_quantity, 'incorrect max').to.eq(max);",
+                      "}"
+                    ],
+                    "type": "text/javascript"
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "*/*"
+                  },
+                  {
+                    "key": "X-Shopgate-Auth-User",
+                    "value": "{{gen_sg_header_auth_user}}"
+                  },
+                  {
+                    "key": "X-Shopgate-Auth-Token",
+                    "value": "{{gen_sg_header_auth_token}}"
+                  }
+                ],
+                "body": {
+                  "mode": "formdata",
+                  "formdata": [
+                    {
+                      "key": "shop_number",
+                      "value": "{{sg_shop_number}}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "action",
+                      "value": "{{framework_action_get_items}}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "limit",
+                      "value": "5",
+                      "type": "text"
+                    },
+                    {
+                      "key": "offset",
+                      "value": "0",
+                      "type": "text"
+                    },
+                    {
+                      "key": "uids[]",
+                      "value": "{{created_product2_id}}",
+                      "type": "text"
+                    }
+                  ]
+                },
+                "url": {
+                  "raw": "{{sg_endpoint_api}}/getItems",
+                  "host": [
+                    "{{sg_endpoint_api}}"
+                  ],
+                  "path": [
+                    "getItems"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "SG: enable adv price export",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      "",
+                      "pm.test(\"disable setting\", function () {",
+                      "    var jsonData = pm.response.json();",
+                      "    pm.expect(jsonData.shopgate_settings).lengthOf(1);",
+                      "    pm.expect(jsonData.shopgate_settings[0].old).to.eq(\"1\");",
+                      "    pm.expect(jsonData.shopgate_settings[0].new).to.eq(\"0\");",
+                      "});"
+                    ],
+                    "type": "text/javascript"
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "X-Shopgate-Auth-User",
+                    "value": "{{gen_sg_header_auth_user}}"
+                  },
+                  {
+                    "key": "X-Shopgate-Auth-Token",
+                    "value": "{{gen_sg_header_auth_token}}"
+                  }
+                ],
+                "body": {
+                  "mode": "formdata",
+                  "formdata": [
+                    {
+                      "key": "shop_number",
+                      "value": "{{sg_shop_number}}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "action",
+                      "value": "{{framework_action_set_settings}}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "shopgate_settings[0][name]",
+                      "value": "skip_advanced_price_export",
+                      "type": "text"
+                    },
+                    {
+                      "key": "shopgate_settings[0][value]",
+                      "value": "0",
+                      "type": "text"
+                    }
+                  ]
+                },
+                "url": {
+                  "raw": "{{sg_endpoint_api}}/setSettings",
+                  "host": [
+                    "{{sg_endpoint_api}}"
+                  ],
+                  "path": [
+                    "setSettings"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "SG: check prices",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      "",
+                      "pm.test(\"Not an error\", function () {",
+                      "    pm.response.to.not.have.jsonBody('error');",
+                      "});",
+                      "",
+                      "var jsonObject = xml2Json(responseBody);",
+                      "pm.test(\"Check products have categories exported\", () => {",
+                      "    pm.expect(jsonObject.items.item.prices).to.not.be.undefined;",
+                      "    const price = jsonObject.items.item.prices;",
+                      "    pm.expect(price.price).to.eq('500');",
+                      "    pm.expect(price.sale_price).to.eq('400');",
+                      "    pm.expect(price.base_price).to.contain('200');",
+                      "    pm.expect(price.price).to.eq('500');",
+                      "});",
+                      "",
+                      "pm.test(\"Check tier prices\", () => {",
+                      "    pm.expect(jsonObject.items.item.prices.tier_prices.tier_price).to.not.be.undefined;",
+                      "    const tiers = jsonObject.items.item.prices.tier_prices.tier_price;",
+                      "    checkGrp(tiers[0], '10', '5', 'percent', '1');",
+                      "    checkGrp(tiers[1], '20', '10', 'percent', '1');",
+                      "    checkGrp(tiers[2], '50', '15', 'percent', '1');",
+                      "    checkFixedDiscount(tiers[3], '200', '2', 'fixed', '3');",
+                      "});",
+                      "",
+                      "function checkGrp(tier, discount, min, type, customerGrpId) {",
+                      "    pm.expect(tier._, 'incorrect discount').to.eq(discount);",
+                      "    pm.expect(tier.$.threshold, 'incorrect threshold').to.eq(min);",
+                      "    pm.expect(tier.$.type, 'icnorrect type').to.eq(type);",
+                      "    if (customerGrpId) {",
+                      "        pm.expect(tier.$.customer_group_uid, 'incorrect customer grp').to.eq(customerGrpId);",
+                      "    }",
+                      "}",
+                      "function checkFixedDiscount(tier, discount, min, type, max) {",
+                      "    checkGrp(tier, discount, min, type, null);",
+                      "    pm.expect(tier.$.max_quantity, 'incorrect max').to.eq(max);",
+                      "}"
+                    ],
+                    "type": "text/javascript"
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "*/*"
+                  },
+                  {
+                    "key": "X-Shopgate-Auth-User",
+                    "value": "{{gen_sg_header_auth_user}}"
+                  },
+                  {
+                    "key": "X-Shopgate-Auth-Token",
+                    "value": "{{gen_sg_header_auth_token}}"
+                  }
+                ],
+                "body": {
+                  "mode": "formdata",
+                  "formdata": [
+                    {
+                      "key": "shop_number",
+                      "value": "{{sg_shop_number}}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "action",
+                      "value": "{{framework_action_get_items}}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "limit",
+                      "value": "5",
+                      "type": "text"
+                    },
+                    {
+                      "key": "offset",
+                      "value": "0",
+                      "type": "text"
+                    },
+                    {
+                      "key": "uids[]",
+                      "value": "{{created_product2_id}}",
+                      "type": "text"
+                    }
+                  ]
+                },
+                "url": {
+                  "raw": "{{sg_endpoint_api}}/getItems",
+                  "host": [
+                    "{{sg_endpoint_api}}"
+                  ],
+                  "path": [
+                    "getItems"
+                  ]
+                }
+              },
+              "response": []
+            }
+          ]
         }
+      ],
+      "description": "Catalog export related tests"
+    },
+    {
+      "name": "Deactivate shop test",
+      "item": [
+        {
+          "name": "SG: try deactivate store",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Status code is 200\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"de-activation via plugin is not implemented\", function () {",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.expect(jsonData.shopgate_settings).lengthOf(1);",
+                  "    pm.expect(jsonData.shopgate_settings[0].old).to.eq(false);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "X-Shopgate-Auth-User",
+                "value": "{{gen_sg_header_auth_user}}"
+              },
+              {
+                "key": "X-Shopgate-Auth-Token",
+                "value": "{{gen_sg_header_auth_token}}"
+              }
+            ],
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                {
+                  "key": "shop_number",
+                  "value": "{{sg_shop_number}}",
+                  "type": "text"
+                },
+                {
+                  "key": "action",
+                  "value": "{{framework_action_set_settings}}",
+                  "type": "text"
+                },
+                {
+                  "key": "shopgate_settings[0][name]",
+                  "value": "shop_is_active",
+                  "type": "text"
+                },
+                {
+                  "key": "shopgate_settings[0][value]",
+                  "value": "0",
+                  "type": "text"
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{sg_endpoint_api}}/setSettings",
+              "host": [
+                "{{sg_endpoint_api}}"
+              ],
+              "path": [
+                "setSettings"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "SW: config cache clear",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Status code is 200\", function () {\r",
+                  "    pm.response.to.have.status(200);\r",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{sw_endpoint_api}}/caches/config",
+              "host": [
+                "{{sw_endpoint_api}}"
+              ],
+              "path": [
+                "caches",
+                "config"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "SG: ping",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Status code is 200\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"Ping works\", function () {",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.expect(jsonData.pong).to.eq('OK');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "X-Shopgate-Auth-User",
+                "value": "{{gen_sg_header_auth_user}}"
+              },
+              {
+                "key": "X-Shopgate-Auth-Token",
+                "value": "{{gen_sg_header_auth_token}}"
+              }
+            ],
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                {
+                  "key": "shop_number",
+                  "value": "{{sg_shop_number}}",
+                  "type": "text"
+                },
+                {
+                  "key": "action",
+                  "value": "{{framework_action_set_settings}}",
+                  "type": "text"
+                },
+                {
+                  "key": "shopgate_settings[0][name]",
+                  "value": "shop_is_active",
+                  "type": "text"
+                },
+                {
+                  "key": "shopgate_settings[0][value]",
+                  "value": "0",
+                  "type": "text"
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{sg_endpoint_api}}/ping",
+              "host": [
+                "{{sg_endpoint_api}}"
+              ],
+              "path": [
+                "ping"
+              ]
+            }
+          },
+          "response": []
+        }
+      ],
+      "description": "SG runs a deactivation script after every import, so we need to make sure the store does not get deactivated by it\n\n```\n[shopgate_settings] => Array\n       (\n            [0] => Array\n                (\n                    [name] => shop_is_active\n                    [value] => 0\n                )\n\n        )\n\n\n```\n\nStartFragment"
+    },
+    {
+      "name": "Cleanup",
+      "item": [
+        {
+          "name": "SW: remove prod 1",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Status code is 200\", function () {\r",
+                  "    pm.response.to.have.status(200);\r",
+                  "});\r",
+                  "\r",
+                  "pm.test(\"Check success\", function () {\r",
+                  "    var jsonData = pm.response.json();\r",
+                  "    pm.expect(jsonData.success).to.eq(true);\r",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{sw_endpoint_api}}/articles/:articleId",
+              "host": [
+                "{{sw_endpoint_api}}"
+              ],
+              "path": [
+                "articles",
+                ":articleId"
+              ],
+              "variable": [
+                {
+                  "key": "articleId",
+                  "value": "{{created_product1_id}}"
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "SW: remove prod 2",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Status code is 200\", function () {\r",
+                  "    pm.response.to.have.status(200);\r",
+                  "});\r",
+                  "\r",
+                  "pm.test(\"Check success\", function () {\r",
+                  "    var jsonData = pm.response.json();\r",
+                  "    pm.expect(jsonData.success).to.eq(true);\r",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{sw_endpoint_api}}/articles/:articleId",
+              "host": [
+                "{{sw_endpoint_api}}"
+              ],
+              "path": [
+                "articles",
+                ":articleId"
+              ],
+              "variable": [
+                {
+                  "key": "articleId",
+                  "value": "{{created_product2_id}}"
+                }
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "WebCheckout",
+      "item": [
+        {
+          "name": "SW: Get customer 1",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "exec": [
+                  "// allowCookie=1\r",
+                  "const jar = pm.cookies.jar();\r",
+                  "jar.set(pm.environment.get(\"host\"), 'allowCookie', '1');"
+                ],
+                "type": "text/javascript"
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Status code is 200\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"get customer data\", function () {",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.expect(jsonData.data).to.not.be.undefined;",
+                  "    pm.expect(jsonData.data.number).to.not.be.undefined;",
+                  "    pm.environment.set('gen_customer_1_num', jsonData.data.number);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{sw_endpoint_api}}/customers/1",
+              "host": [
+                "{{sw_endpoint_api}}"
+              ],
+              "path": [
+                "customers",
+                "1"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "SG: login customer",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "// Load the HTML response to $",
+                  "const $ = cheerio.load(pm.response.text());",
+                  "pm.test(\"Check that customer got logged in\", function () {",
+                  "    const greeting = $('.account--display-greeting');",
+                  "    pm.expect(greeting).to.be.not.undefined;",
+                  "    pm.expect(greeting.text()).to.contain('Max');",
+                  "});",
+                  "",
+                  "// Allow cookie deletion by going to cookies -> Domain Allowlist",
+                  "const jar = pm.cookies.jar();",
+                  "jar.unset(pm.environment.get(\"host\"), 'session-1', (error) => error && console.log(error.message));",
+                  "jar.unset(pm.environment.get(\"host\"), 'slt', (error) => error && console.log(error.message));"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "jwt",
+              "jwt": [
+                {
+                  "key": "payload",
+                  "value": "{\"customer_id\": \"{{gen_customer_1_num}}\"}",
+                  "type": "string"
+                },
+                {
+                  "key": "addTokenTo",
+                  "value": "queryParam",
+                  "type": "string"
+                },
+                {
+                  "key": "secret",
+                  "value": "{{sg_api_key}}",
+                  "type": "string"
+                },
+                {
+                  "key": "isSecretBase64Encoded",
+                  "value": false,
+                  "type": "boolean"
+                },
+                {
+                  "key": "algorithm",
+                  "value": "HS256",
+                  "type": "string"
+                },
+                {
+                  "key": "headerPrefix",
+                  "value": "Bearer",
+                  "type": "string"
+                },
+                {
+                  "key": "queryParamKey",
+                  "value": "token",
+                  "type": "string"
+                },
+                {
+                  "key": "header",
+                  "value": "{}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [
+              {
+                "key": "User-Agent",
+                "value": "PostmanRuntime libshopgate",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{sg_endpoint_api}}/login",
+              "host": [
+                "{{sg_endpoint_api}}"
+              ],
+              "path": [
+                "login"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "SG: create guest cart",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Status code is 201\", function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "pm.test(\"Get session\", function () {",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.expect(jsonData.sessionId).to.not.be.undefined;",
+                  "    pm.environment.set('gen_sessionId_guest', jsonData.sessionId);",
+                  "});",
+                  "",
+                  "",
+                  "// Allow cookie deletion by going to cookies -> Domain Allowlist",
+                  "const jar = pm.cookies.jar();",
+                  "jar.unset(pm.environment.get(\"host\"), 'session-1', (error) => error && console.log(error.message));",
+                  "jar.unset(pm.environment.get(\"host\"), 'slt', (error) => error && console.log(error.message));"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "User-Agent",
+                "value": "Shopgate PWA",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"articles\": [\n        {\n            \"product_id\": \"{{gen_product_main_id}}\",\n            \"variant_id\": \"\",\n            \"quantity\": 1,\n            \"options\": []\n        }\n    ],\n    \"customerId\": null\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{sg_endpoint_api}}/addToCart",
+              "host": [
+                "{{sg_endpoint_api}}"
+              ],
+              "path": [
+                "addToCart"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "SG: login guest",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "// Load the HTML response to $",
+                  "const $ = cheerio.load(pm.response.text());",
+                  "pm.test(\"Check that guest got logged in\", function () {",
+                  "    const productInCart = $('.content--sku.content');",
+                  "    pm.expect(productInCart).to.be.not.undefined;",
+                  "    pm.expect(productInCart.text()).to.contain('SW10001');",
+                  "});",
+                  "",
+                  "// Allow cookie deletion by going to cookies -> Domain Allowlist",
+                  "const jar = pm.cookies.jar();",
+                  "jar.unset(pm.environment.get(\"host\"), 'session-1', (error) => error && console.log(error.message));",
+                  "jar.unset(pm.environment.get(\"host\"), 'slt', (error) => error && console.log(error.message));"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{sg_endpoint_api}}/login?sessionId={{gen_sessionId_guest}}&guest=1&redirectTo=checkout.cart",
+              "host": [
+                "{{sg_endpoint_api}}"
+              ],
+              "path": [
+                "login"
+              ],
+              "query": [
+                {
+                  "key": "sessionId",
+                  "value": "{{gen_sessionId_guest}}"
+                },
+                {
+                  "key": "guest",
+                  "value": "1"
+                },
+                {
+                  "key": "redirectTo",
+                  "value": "checkout.cart"
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "SG: login & prod page",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "// Load the HTML response to $",
+                  "const $ = cheerio.load(pm.response.text());",
+                  "pm.test(\"Check that we have a sessionId being sent to App\", function () {",
+                  "    const session = $('script:contains(\"sessionId\")');",
+                  "    pm.expect(session).to.be.not.undefined;",
+                  "    pm.expect(session.text()).to.contain(\"{'sessionId': '\");",
+                  "});",
+                  "",
+                  "// Allow cookie deletion by going to cookies -> Domain Allowlist",
+                  "const jar = pm.cookies.jar();",
+                  "jar.unset(pm.environment.get(\"host\"), 'session-1', (error) => error && console.log(error.message));",
+                  "jar.unset(pm.environment.get(\"host\"), 'slt', (error) => error && console.log(error.message));"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "jwt",
+              "jwt": [
+                {
+                  "key": "payload",
+                  "value": "{\"customer_id\": \"{{gen_customer_1_num}}\"}",
+                  "type": "string"
+                },
+                {
+                  "key": "addTokenTo",
+                  "value": "queryParam",
+                  "type": "string"
+                },
+                {
+                  "key": "secret",
+                  "value": "{{sg_api_key}}",
+                  "type": "string"
+                },
+                {
+                  "key": "isSecretBase64Encoded",
+                  "value": false,
+                  "type": "boolean"
+                },
+                {
+                  "key": "algorithm",
+                  "value": "HS256",
+                  "type": "string"
+                },
+                {
+                  "key": "headerPrefix",
+                  "value": "Bearer",
+                  "type": "string"
+                },
+                {
+                  "key": "queryParamKey",
+                  "value": "token",
+                  "type": "string"
+                },
+                {
+                  "key": "header",
+                  "value": "{}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [
+              {
+                "key": "User-Agent",
+                "value": "PostmanRuntime libshopgate",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{sg_endpoint_api}}/login?redirectTo=detail.index.sArticle.3",
+              "host": [
+                "{{sg_endpoint_api}}"
+              ],
+              "path": [
+                "login"
+              ],
+              "query": [
+                {
+                  "key": "redirectTo",
+                  "value": "detail.index.sArticle.3"
+                }
+              ]
+            },
+            "description": "Logs in, redirects to product page & checks that the session is being sent to the App."
+          },
+          "response": []
+        }
+      ]
+    }
+  ],
+  "auth": {
+    "type": "basic",
+    "basic": [
+      {
+        "key": "password",
+        "value": "{{sw_api_key}}",
+        "type": "string"
+      },
+      {
+        "key": "username",
+        "value": "demo",
+        "type": "string"
+      }
     ]
+  },
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "exec": [
+          "/**",
+          " *  SG Token generation",
+          " */",
+          "var tstamp = Math.floor(Date.now() / 1000);",
+          "",
+          "// Use the CryptoJS",
+          "var authUser = pm.environment.get('sg_customer_number') + \"-\" + tstamp;",
+          "var tokenData = \"SPA-\" + pm.environment.get('sg_customer_number') + \"-\" + tstamp + \"-\" + pm.environment.get('sg_api_key');",
+          "",
+          "var authToken = CryptoJS.SHA1(tokenData).toString();",
+          "",
+          "// Set the new header values",
+          "pm.environment.set(\"gen_sg_header_auth_user\", authUser);",
+          "pm.environment.set(\"gen_sg_header_auth_token\", authToken);"
+        ]
+      }
+    },
+    {
+      "listen": "test",
+      "script": {
+        "type": "text/javascript",
+        "exec": [
+          ""
+        ]
+      }
+    }
+  ]
 }

--- a/tests/Postman/collection.json
+++ b/tests/Postman/collection.json
@@ -1,832 +1,1918 @@
 {
-  "info": {
-    "_postman_id": "4048853c-24aa-43d6-9b82-103c975547b1",
-    "name": "Shopware 5 (Go)",
-    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "_exporter_id": "5289226"
-  },
-  "item": [
-    {
-      "name": "Init",
-      "item": [
-        {
-          "name": "System",
-          "item": [
-            {
-              "name": "SW: Get shop info",
-              "event": [
-                {
-                  "listen": "prerequest",
-                  "script": {
-                    "exec": [
-                      "// allowCookie=1\r",
-                      "const jar = pm.cookies.jar();\r",
-                      "jar.set(pm.environment.get(\"host\"), 'allowCookie', '1');"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{sw_endpoint_api}}/shops/1",
-                  "host": [
-                    "{{sw_endpoint_api}}"
-                  ],
-                  "path": [
-                    "shops",
-                    "1"
-                  ]
-                }
-              },
-              "response": []
-            }
-          ]
-        },
-        {
-          "name": "Product",
-          "item": [
-            {
-              "name": "SW: Get main product",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status code is 200\", function () {\r",
-                      "    pm.response.to.have.status(200);\r",
-                      "});\r",
-                      "\r",
-                      "pm.test(\"Get main product\", function () {\r",
-                      "    var jsonData = pm.response.json();\r",
-                      "    pm.expect(jsonData.data).to.haveOwnProperty('id').to.be.a('number');\r",
-                      "    pm.environment.set(\"gen_product_main_id\", jsonData.data.id);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{sw_endpoint_api}}/articles/SW10001?useNumberAsId=true",
-                  "host": [
-                    "{{sw_endpoint_api}}"
-                  ],
-                  "path": [
-                    "articles",
-                    "SW10001"
-                  ],
-                  "query": [
-                    {
-                      "key": "useNumberAsId",
-                      "value": "true"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "SW: Get main category",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status code is 200\", function () {\r",
-                      "    pm.response.to.have.status(200);\r",
-                      "});\r",
-                      "\r",
-                      "pm.test(\"Get main category\", function () {\r",
-                      "    var jsonData = pm.response.json();\r",
-                      "    pm.expect(jsonData.data[0]).to.haveOwnProperty('id').to.be.a('number');\r",
-                      "    pm.environment.set(\"gen_category_main_id\", jsonData.data[0].id);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "protocolProfileBehavior": {
-                "disableBodyPruning": true
-              },
-              "request": {
-                "method": "GET",
-                "header": [],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\r\n    \"filter\": [\r\n        {\r\n            \"property\": \"parentId\",\r\n            \"expression\": \">\",\r\n            \"value\": \"1\"\r\n        }\r\n    ],\r\n    \"limit\": 1\r\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{sw_endpoint_api}}/categories",
-                  "host": [
-                    "{{sw_endpoint_api}}"
-                  ],
-                  "path": [
-                    "categories"
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "SW: create product",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status code is 201\", function () {\r",
-                      "    pm.response.to.have.status(201);\r",
-                      "});\r",
-                      "\r",
-                      "pm.test(\"Get id of created product\", function () {\r",
-                      "    var jsonData = pm.response.json();\r",
-                      "    pm.expect(jsonData.data.id).to.be.a(\"number\");\r",
-                      "    pm.environment.set('created_product1_id', jsonData.data.id);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\r\n    \"name\": \"API: disabled product\",\r\n    \"active\": false,\r\n    \"tax\": 19,\r\n    \"supplier\": \"Sport Shoes Inc.\",\r\n    \"categories\": [\r\n        {\r\n            \"id\": {{gen_category_main_id}}\r\n        }\r\n    ],\r\n    \"mainDetail\": {\r\n        \"number\": \"API-INACTIVE\",\r\n        \"active\": true,\r\n        \"prices\": [\r\n            {\r\n                \"customerGroupKey\": \"EK\",\r\n                \"price\": 999\r\n            }\r\n        ]\r\n    }\r\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{sw_endpoint_api}}/articles",
-                  "host": [
-                    "{{sw_endpoint_api}}"
-                  ],
-                  "path": [
-                    "articles"
-                  ]
-                }
-              },
-              "response": []
-            }
-          ]
-        }
-      ]
+    "info": {
+        "_postman_id": "72babe50-8d15-4025-b1b2-bf064719644a",
+        "name": "Shopware 5 (Go)",
+        "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+        "_exporter_id": "5289226"
     },
-    {
-      "name": "Export inactive",
-      "item": [
+    "item": [
         {
-          "name": "SG: try inactive export",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test(\"Status code is 200\", function () {",
-                  "    pm.response.to.have.status(200);",
-                  "});",
-                  "",
-                  "pm.test(\"Make sure the product is not exported as it's inactive\", function () {",
-                  "    var jsonData = pm.response.json();",
-                  "    pm.expect(jsonData.error).to.eql(82);",
-                  "});"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Accept",
-                "value": "*/*"
-              },
-              {
-                "key": "X-Shopgate-Auth-User",
-                "value": "{{gen_sg_header_auth_user}}"
-              },
-              {
-                "key": "X-Shopgate-Auth-Token",
-                "value": "{{gen_sg_header_auth_token}}"
-              }
-            ],
-            "body": {
-              "mode": "formdata",
-              "formdata": [
+            "name": "Init",
+            "item": [
                 {
-                  "key": "shop_number",
-                  "value": "{{sg_shop_number}}",
-                  "type": "text"
+                    "name": "System",
+                    "item": [
+                        {
+                            "name": "SW: Get shop info",
+                            "event": [
+                                {
+                                    "listen": "prerequest",
+                                    "script": {
+                                        "exec": [
+                                            "// allowCookie=1\r",
+                                            "const jar = pm.cookies.jar();\r",
+                                            "jar.set(pm.environment.get(\"host\"), 'allowCookie', '1');"
+                                        ],
+                                        "type": "text/javascript"
+                                    }
+                                }
+                            ],
+                            "request": {
+                                "method": "GET",
+                                "header": [],
+                                "url": {
+                                    "raw": "{{sw_endpoint_api}}/shops/1",
+                                    "host": [
+                                        "{{sw_endpoint_api}}"
+                                    ],
+                                    "path": [
+                                        "shops",
+                                        "1"
+                                    ]
+                                }
+                            },
+                            "response": []
+                        }
+                    ]
                 },
                 {
-                  "key": "action",
-                  "value": "{{framework_action_get_items}}",
-                  "type": "text"
-                },
-                {
-                  "key": "limit",
-                  "value": "5",
-                  "type": "text"
-                },
-                {
-                  "key": "offset",
-                  "value": "0",
-                  "type": "text"
-                },
-                {
-                  "key": "uids[]",
-                  "value": "{{created_product1_id}}",
-                  "type": "text"
+                    "name": "Product",
+                    "item": [
+                        {
+                            "name": "SW: Get main product",
+                            "event": [
+                                {
+                                    "listen": "test",
+                                    "script": {
+                                        "exec": [
+                                            "pm.test(\"Status code is 200\", function () {\r",
+                                            "    pm.response.to.have.status(200);\r",
+                                            "});\r",
+                                            "\r",
+                                            "pm.test(\"Get main product\", function () {\r",
+                                            "    var jsonData = pm.response.json();\r",
+                                            "    pm.expect(jsonData.data).to.haveOwnProperty('id').to.be.a('number');\r",
+                                            "    pm.environment.set(\"gen_product_main_id\", jsonData.data.id);\r",
+                                            "});"
+                                        ],
+                                        "type": "text/javascript"
+                                    }
+                                }
+                            ],
+                            "request": {
+                                "method": "GET",
+                                "header": [],
+                                "url": {
+                                    "raw": "{{sw_endpoint_api}}/articles/SW10001?useNumberAsId=true",
+                                    "host": [
+                                        "{{sw_endpoint_api}}"
+                                    ],
+                                    "path": [
+                                        "articles",
+                                        "SW10001"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "useNumberAsId",
+                                            "value": "true"
+                                        }
+                                    ]
+                                }
+                            },
+                            "response": []
+                        },
+                        {
+                            "name": "SW: Get main category",
+                            "event": [
+                                {
+                                    "listen": "test",
+                                    "script": {
+                                        "exec": [
+                                            "pm.test(\"Status code is 200\", function () {\r",
+                                            "    pm.response.to.have.status(200);\r",
+                                            "});\r",
+                                            "\r",
+                                            "pm.test(\"Get main category\", function () {\r",
+                                            "    var jsonData = pm.response.json();\r",
+                                            "    pm.expect(jsonData.data[0]).to.haveOwnProperty('id').to.be.a('number');\r",
+                                            "    pm.environment.set(\"gen_category_main_id\", jsonData.data[0].id);\r",
+                                            "});"
+                                        ],
+                                        "type": "text/javascript"
+                                    }
+                                }
+                            ],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            },
+                            "request": {
+                                "method": "GET",
+                                "header": [],
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\r\n    \"filter\": [\r\n        {\r\n            \"property\": \"parentId\",\r\n            \"expression\": \">\",\r\n            \"value\": \"1\"\r\n        }\r\n    ],\r\n    \"limit\": 1\r\n}",
+                                    "options": {
+                                        "raw": {
+                                            "language": "json"
+                                        }
+                                    }
+                                },
+                                "url": {
+                                    "raw": "{{sw_endpoint_api}}/categories",
+                                    "host": [
+                                        "{{sw_endpoint_api}}"
+                                    ],
+                                    "path": [
+                                        "categories"
+                                    ]
+                                }
+                            },
+                            "response": []
+                        },
+                        {
+                            "name": "SW: create inactive prod",
+                            "event": [
+                                {
+                                    "listen": "test",
+                                    "script": {
+                                        "exec": [
+                                            "pm.test(\"Status code is 201\", function () {\r",
+                                            "    pm.response.to.have.status(201);\r",
+                                            "});\r",
+                                            "\r",
+                                            "pm.test(\"Get id of created product\", function () {\r",
+                                            "    var jsonData = pm.response.json();\r",
+                                            "    pm.expect(jsonData.data.id).to.be.a(\"number\");\r",
+                                            "    pm.environment.set('created_product1_id', jsonData.data.id);\r",
+                                            "});"
+                                        ],
+                                        "type": "text/javascript"
+                                    }
+                                }
+                            ],
+                            "request": {
+                                "method": "POST",
+                                "header": [],
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\r\n    \"name\": \"API: disabled product\",\r\n    \"active\": false,\r\n    \"tax\": 19,\r\n    \"supplier\": \"Sport Shoes Inc.\",\r\n    \"categories\": [\r\n        {\r\n            \"id\": {{gen_category_main_id}}\r\n        }\r\n    ],\r\n    \"mainDetail\": {\r\n        \"number\": \"API-INACTIVE\",\r\n        \"active\": true,\r\n        \"prices\": [\r\n            {\r\n                \"customerGroupKey\": \"EK\",\r\n                \"price\": 999\r\n            }\r\n        ]\r\n    }\r\n}",
+                                    "options": {
+                                        "raw": {
+                                            "language": "json"
+                                        }
+                                    }
+                                },
+                                "url": {
+                                    "raw": "{{sw_endpoint_api}}/articles",
+                                    "host": [
+                                        "{{sw_endpoint_api}}"
+                                    ],
+                                    "path": [
+                                        "articles"
+                                    ]
+                                }
+                            },
+                            "response": []
+                        },
+                        {
+                            "name": "SW: create price grp",
+                            "event": [
+                                {
+                                    "listen": "test",
+                                    "script": {
+                                        "exec": [
+                                            "pm.test(\"Status code is 201\", function () {\r",
+                                            "    pm.response.to.have.status(201);\r",
+                                            "});\r",
+                                            "\r",
+                                            "pm.test(\"Get id of created product\", function () {\r",
+                                            "    var jsonData = pm.response.json();\r",
+                                            "    pm.expect(jsonData.data.id).to.be.a(\"number\");\r",
+                                            "    pm.environment.set('created_product2_id', jsonData.data.id);\r",
+                                            "});"
+                                        ],
+                                        "type": "text/javascript"
+                                    }
+                                }
+                            ],
+                            "request": {
+                                "method": "POST",
+                                "header": [],
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\r\n    \"name\": \"API: price grp product\",\r\n    \"active\": true,\r\n    \"tax\": 19,\r\n    \"supplier\": \"Active Runners LLC\",\r\n    \"categories\": [\r\n        {\r\n            \"id\": {{gen_category_main_id}}\r\n        }\r\n    ],\r\n    \"lastStock\": true, // stock cannot go into negatives (saleable)\r\n    \"priceGroupActive\": true,\r\n    \"priceGroupId\": 500,\r\n    \"mainDetail\": {\r\n        \"number\": \"API-PRICE-GRP\",\r\n        \"active\": true,\r\n        \"prices\": [\r\n            {\r\n                \"customerGroupKey\": \"EK\",\r\n                \"from\": \"1\",\r\n                \"to\": \"3\",\r\n                \"price\": 200,\r\n                \"pseudoPrice\": 250, // fake price to cross out\r\n                \"basePrice\": 90\r\n            },\r\n            {\r\n                \"customerGroupKey\": \"EK\",\r\n                \"from\": \"4\",\r\n                \"to\": \"7\",\r\n                \"price\": 100,\r\n                \"pseudoPrice\": 250,\r\n                \"basePrice\": 90\r\n            }\r\n        ],\r\n        \"inStock\": 500,\r\n        \"minPurchase\": 2,\r\n        \"maxPurchase\": 10,\r\n        \"purchaseSteps\": 2,\r\n        \"position\": 5\r\n    }\r\n}",
+                                    "options": {
+                                        "raw": {
+                                            "language": "json"
+                                        }
+                                    }
+                                },
+                                "url": {
+                                    "raw": "{{sw_endpoint_api}}/articles",
+                                    "host": [
+                                        "{{sw_endpoint_api}}"
+                                    ],
+                                    "path": [
+                                        "articles"
+                                    ]
+                                }
+                            },
+                            "response": []
+                        }
+                    ]
                 }
-              ]
-            },
-            "url": {
-              "raw": "{{sg_endpoint_api}}/getItems",
-              "host": [
-                "{{sg_endpoint_api}}"
-              ],
-              "path": [
-                "getItems"
-              ]
-            }
-          },
-          "response": []
+            ]
         },
         {
-          "name": "SG: set export inactive",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test(\"Status code is 200\", function () {",
-                  "    pm.response.to.have.status(200);",
-                  "});",
-                  "",
-                  "pm.test(\"enable inactive product export\", function () {",
-                  "    var jsonData = pm.response.json();",
-                  "    pm.expect(jsonData.shopgate_settings).lengthOf(1);",
-                  "    pm.expect(jsonData.shopgate_settings[0].new).to.eq(\"1\");",
-                  "});"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "X-Shopgate-Auth-User",
-                "value": "{{gen_sg_header_auth_user}}"
-              },
-              {
-                "key": "X-Shopgate-Auth-Token",
-                "value": "{{gen_sg_header_auth_token}}"
-              }
-            ],
-            "body": {
-              "mode": "formdata",
-              "formdata": [
+            "name": "Catalog",
+            "item": [
                 {
-                  "key": "shop_number",
-                  "value": "{{sg_shop_number}}",
-                  "type": "text"
+                    "name": "Export inactive",
+                    "item": [
+                        {
+                            "name": "SG: try inactive export",
+                            "event": [
+                                {
+                                    "listen": "test",
+                                    "script": {
+                                        "exec": [
+                                            "pm.test(\"Status code is 200\", function () {",
+                                            "    pm.response.to.have.status(200);",
+                                            "});",
+                                            "",
+                                            "pm.test(\"Make sure the product is not exported as it's inactive\", function () {",
+                                            "    var jsonData = pm.response.json();",
+                                            "    pm.expect(jsonData.error).to.eql(82);",
+                                            "});"
+                                        ],
+                                        "type": "text/javascript"
+                                    }
+                                }
+                            ],
+                            "request": {
+                                "method": "POST",
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "*/*"
+                                    },
+                                    {
+                                        "key": "X-Shopgate-Auth-User",
+                                        "value": "{{gen_sg_header_auth_user}}"
+                                    },
+                                    {
+                                        "key": "X-Shopgate-Auth-Token",
+                                        "value": "{{gen_sg_header_auth_token}}"
+                                    }
+                                ],
+                                "body": {
+                                    "mode": "formdata",
+                                    "formdata": [
+                                        {
+                                            "key": "shop_number",
+                                            "value": "{{sg_shop_number}}",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "key": "action",
+                                            "value": "{{framework_action_get_items}}",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "key": "limit",
+                                            "value": "5",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "key": "offset",
+                                            "value": "0",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "key": "uids[]",
+                                            "value": "{{created_product1_id}}",
+                                            "type": "text"
+                                        }
+                                    ]
+                                },
+                                "url": {
+                                    "raw": "{{sg_endpoint_api}}/getItems",
+                                    "host": [
+                                        "{{sg_endpoint_api}}"
+                                    ],
+                                    "path": [
+                                        "getItems"
+                                    ]
+                                }
+                            },
+                            "response": []
+                        },
+                        {
+                            "name": "SG: set export inactive",
+                            "event": [
+                                {
+                                    "listen": "test",
+                                    "script": {
+                                        "exec": [
+                                            "pm.test(\"Status code is 200\", function () {",
+                                            "    pm.response.to.have.status(200);",
+                                            "});",
+                                            "",
+                                            "pm.test(\"enable inactive product export\", function () {",
+                                            "    var jsonData = pm.response.json();",
+                                            "    pm.expect(jsonData.shopgate_settings).lengthOf(1);",
+                                            "    pm.expect(jsonData.shopgate_settings[0].new).to.eq(\"1\");",
+                                            "});"
+                                        ],
+                                        "type": "text/javascript"
+                                    }
+                                }
+                            ],
+                            "request": {
+                                "method": "POST",
+                                "header": [
+                                    {
+                                        "key": "X-Shopgate-Auth-User",
+                                        "value": "{{gen_sg_header_auth_user}}"
+                                    },
+                                    {
+                                        "key": "X-Shopgate-Auth-Token",
+                                        "value": "{{gen_sg_header_auth_token}}"
+                                    }
+                                ],
+                                "body": {
+                                    "mode": "formdata",
+                                    "formdata": [
+                                        {
+                                            "key": "shop_number",
+                                            "value": "{{sg_shop_number}}",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "key": "action",
+                                            "value": "{{framework_action_set_settings}}",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "key": "shopgate_settings[0][name]",
+                                            "value": "export_product_inactive",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "key": "shopgate_settings[0][value]",
+                                            "value": "1",
+                                            "type": "text"
+                                        }
+                                    ]
+                                },
+                                "url": {
+                                    "raw": "{{sg_endpoint_api}}/setSettings",
+                                    "host": [
+                                        "{{sg_endpoint_api}}"
+                                    ],
+                                    "path": [
+                                        "setSettings"
+                                    ]
+                                }
+                            },
+                            "response": []
+                        },
+                        {
+                            "name": "SW: config cache clear",
+                            "event": [
+                                {
+                                    "listen": "test",
+                                    "script": {
+                                        "exec": [
+                                            "pm.test(\"Status code is 200\", function () {\r",
+                                            "    pm.response.to.have.status(200);\r",
+                                            "});"
+                                        ],
+                                        "type": "text/javascript"
+                                    }
+                                }
+                            ],
+                            "request": {
+                                "method": "DELETE",
+                                "header": [],
+                                "url": {
+                                    "raw": "{{sw_endpoint_api}}/caches/config",
+                                    "host": [
+                                        "{{sw_endpoint_api}}"
+                                    ],
+                                    "path": [
+                                        "caches",
+                                        "config"
+                                    ]
+                                }
+                            },
+                            "response": []
+                        },
+                        {
+                            "name": "SG: try inactive export",
+                            "event": [
+                                {
+                                    "listen": "test",
+                                    "script": {
+                                        "exec": [
+                                            "pm.test(\"Status code is 200\", function () {",
+                                            "    pm.response.to.have.status(200);",
+                                            "});",
+                                            "",
+                                            "pm.test(\"Not an error\", function () {",
+                                            "    pm.response.to.not.have.jsonBody('error');",
+                                            "});",
+                                            "",
+                                            "pm.test(\"Check product gets exported now\", function () {",
+                                            "    var jsonObject = xml2Json(responseBody);",
+                                            "    pm.expect(jsonObject.items.item.$.uid).to.eql(pm.environment.get('created_product1_id').toString());",
+                                            "    pm.expect(jsonObject.items.item.stock.is_saleable).to.eq('0');",
+                                            "});"
+                                        ],
+                                        "type": "text/javascript"
+                                    }
+                                }
+                            ],
+                            "request": {
+                                "method": "POST",
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "*/*"
+                                    },
+                                    {
+                                        "key": "X-Shopgate-Auth-User",
+                                        "value": "{{gen_sg_header_auth_user}}"
+                                    },
+                                    {
+                                        "key": "X-Shopgate-Auth-Token",
+                                        "value": "{{gen_sg_header_auth_token}}"
+                                    }
+                                ],
+                                "body": {
+                                    "mode": "formdata",
+                                    "formdata": [
+                                        {
+                                            "key": "shop_number",
+                                            "value": "{{sg_shop_number}}",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "key": "action",
+                                            "value": "{{framework_action_get_items}}",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "key": "limit",
+                                            "value": "5",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "key": "offset",
+                                            "value": "0",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "key": "uids[]",
+                                            "value": "{{created_product1_id}}",
+                                            "type": "text"
+                                        }
+                                    ]
+                                },
+                                "url": {
+                                    "raw": "{{sg_endpoint_api}}/getItems",
+                                    "host": [
+                                        "{{sg_endpoint_api}}"
+                                    ],
+                                    "path": [
+                                        "getItems"
+                                    ]
+                                }
+                            },
+                            "response": []
+                        },
+                        {
+                            "name": "SG: unset export inactive",
+                            "event": [
+                                {
+                                    "listen": "test",
+                                    "script": {
+                                        "exec": [
+                                            "pm.test(\"Status code is 200\", function () {",
+                                            "    pm.response.to.have.status(200);",
+                                            "});",
+                                            "",
+                                            "pm.test(\"disable inactive product export\", function () {",
+                                            "    var jsonData = pm.response.json();",
+                                            "    pm.expect(jsonData.shopgate_settings).lengthOf(1);",
+                                            "    pm.expect(jsonData.shopgate_settings[0].new).to.eq(\"0\");",
+                                            "});"
+                                        ],
+                                        "type": "text/javascript"
+                                    }
+                                }
+                            ],
+                            "request": {
+                                "method": "POST",
+                                "header": [
+                                    {
+                                        "key": "X-Shopgate-Auth-User",
+                                        "value": "{{gen_sg_header_auth_user}}"
+                                    },
+                                    {
+                                        "key": "X-Shopgate-Auth-Token",
+                                        "value": "{{gen_sg_header_auth_token}}"
+                                    }
+                                ],
+                                "body": {
+                                    "mode": "formdata",
+                                    "formdata": [
+                                        {
+                                            "key": "shop_number",
+                                            "value": "{{sg_shop_number}}",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "key": "action",
+                                            "value": "{{framework_action_set_settings}}",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "key": "shopgate_settings[0][name]",
+                                            "value": "export_product_inactive",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "key": "shopgate_settings[0][value]",
+                                            "value": "0",
+                                            "type": "text"
+                                        }
+                                    ]
+                                },
+                                "url": {
+                                    "raw": "{{sg_endpoint_api}}/setSettings",
+                                    "host": [
+                                        "{{sg_endpoint_api}}"
+                                    ],
+                                    "path": [
+                                        "setSettings"
+                                    ]
+                                }
+                            },
+                            "response": []
+                        },
+                        {
+                            "name": "SW: config cache clear",
+                            "event": [
+                                {
+                                    "listen": "test",
+                                    "script": {
+                                        "exec": [
+                                            "pm.test(\"Status code is 200\", function () {\r",
+                                            "    pm.response.to.have.status(200);\r",
+                                            "});"
+                                        ],
+                                        "type": "text/javascript"
+                                    }
+                                }
+                            ],
+                            "request": {
+                                "method": "DELETE",
+                                "header": [],
+                                "url": {
+                                    "raw": "{{sw_endpoint_api}}/caches/config",
+                                    "host": [
+                                        "{{sw_endpoint_api}}"
+                                    ],
+                                    "path": [
+                                        "caches",
+                                        "config"
+                                    ]
+                                }
+                            },
+                            "response": []
+                        }
+                    ],
+                    "description": "SG-145 feature request. Exporting inactive products configuration."
                 },
                 {
-                  "key": "action",
-                  "value": "{{framework_action_set_settings}}",
-                  "type": "text"
+                    "name": "Disable Cat Export",
+                    "item": [
+                        {
+                            "name": "SG: disable cat export",
+                            "event": [
+                                {
+                                    "listen": "test",
+                                    "script": {
+                                        "exec": [
+                                            "pm.test(\"Status code is 200\", function () {",
+                                            "    pm.response.to.have.status(200);",
+                                            "});",
+                                            "",
+                                            "pm.test(\"enable setting\", function () {",
+                                            "    var jsonData = pm.response.json();",
+                                            "    pm.expect(jsonData.shopgate_settings).lengthOf(1);",
+                                            "    pm.expect(jsonData.shopgate_settings[0].old).to.eq(\"0\");",
+                                            "    pm.expect(jsonData.shopgate_settings[0].new).to.eq(\"1\");",
+                                            "});"
+                                        ],
+                                        "type": "text/javascript"
+                                    }
+                                }
+                            ],
+                            "request": {
+                                "method": "POST",
+                                "header": [
+                                    {
+                                        "key": "X-Shopgate-Auth-User",
+                                        "value": "{{gen_sg_header_auth_user}}"
+                                    },
+                                    {
+                                        "key": "X-Shopgate-Auth-Token",
+                                        "value": "{{gen_sg_header_auth_token}}"
+                                    }
+                                ],
+                                "body": {
+                                    "mode": "formdata",
+                                    "formdata": [
+                                        {
+                                            "key": "shop_number",
+                                            "value": "{{sg_shop_number}}",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "key": "action",
+                                            "value": "{{framework_action_set_settings}}",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "key": "shopgate_settings[0][name]",
+                                            "value": "skip_category_assignment",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "key": "shopgate_settings[0][value]",
+                                            "value": "1",
+                                            "type": "text"
+                                        }
+                                    ]
+                                },
+                                "url": {
+                                    "raw": "{{sg_endpoint_api}}/setSettings",
+                                    "host": [
+                                        "{{sg_endpoint_api}}"
+                                    ],
+                                    "path": [
+                                        "setSettings"
+                                    ]
+                                }
+                            },
+                            "response": []
+                        },
+                        {
+                            "name": "SG: get items w/o cats",
+                            "event": [
+                                {
+                                    "listen": "test",
+                                    "script": {
+                                        "exec": [
+                                            "pm.test(\"Status code is 200\", function () {",
+                                            "    pm.response.to.have.status(200);",
+                                            "});",
+                                            "",
+                                            "pm.test(\"Not an error\", function () {",
+                                            "    pm.response.to.not.have.jsonBody('error');",
+                                            "});",
+                                            "",
+                                            "var jsonObject = xml2Json(responseBody);",
+                                            "pm.test(\"Check products have no categories exported\", function () {",
+                                            "    console.log(jsonObject)",
+                                            "    jsonObject.items.item.forEach(item => {",
+                                            "        pm.expect(item.categories.category).to.be.undefined;",
+                                            "    });",
+                                            "});"
+                                        ],
+                                        "type": "text/javascript"
+                                    }
+                                }
+                            ],
+                            "request": {
+                                "method": "POST",
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "*/*"
+                                    },
+                                    {
+                                        "key": "X-Shopgate-Auth-User",
+                                        "value": "{{gen_sg_header_auth_user}}"
+                                    },
+                                    {
+                                        "key": "X-Shopgate-Auth-Token",
+                                        "value": "{{gen_sg_header_auth_token}}"
+                                    }
+                                ],
+                                "body": {
+                                    "mode": "formdata",
+                                    "formdata": [
+                                        {
+                                            "key": "shop_number",
+                                            "value": "{{sg_shop_number}}",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "key": "action",
+                                            "value": "{{framework_action_get_items}}",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "key": "limit",
+                                            "value": "5",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "key": "offset",
+                                            "value": "0",
+                                            "type": "text"
+                                        }
+                                    ]
+                                },
+                                "url": {
+                                    "raw": "{{sg_endpoint_api}}/getItems",
+                                    "host": [
+                                        "{{sg_endpoint_api}}"
+                                    ],
+                                    "path": [
+                                        "getItems"
+                                    ]
+                                }
+                            },
+                            "response": []
+                        },
+                        {
+                            "name": "SG: get cats normally",
+                            "event": [
+                                {
+                                    "listen": "test",
+                                    "script": {
+                                        "exec": [
+                                            "pm.test(\"Status code is 200\", function () {",
+                                            "    pm.response.to.have.status(200);",
+                                            "});",
+                                            "",
+                                            "pm.test(\"Not an error\", function () {",
+                                            "    pm.response.to.not.have.jsonBody('error');",
+                                            "});",
+                                            "",
+                                            "var jsonObject = xml2Json(responseBody);",
+                                            "pm.test(\"Check that categories are normally exporting\", function () {",
+                                            "    pm.expect(jsonObject.items.category).to.be.lengthOf(5);",
+                                            "});"
+                                        ],
+                                        "type": "text/javascript"
+                                    }
+                                }
+                            ],
+                            "request": {
+                                "method": "POST",
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "*/*"
+                                    },
+                                    {
+                                        "key": "X-Shopgate-Auth-User",
+                                        "value": "{{gen_sg_header_auth_user}}"
+                                    },
+                                    {
+                                        "key": "X-Shopgate-Auth-Token",
+                                        "value": "{{gen_sg_header_auth_token}}"
+                                    }
+                                ],
+                                "body": {
+                                    "mode": "formdata",
+                                    "formdata": [
+                                        {
+                                            "key": "shop_number",
+                                            "value": "{{sg_shop_number}}",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "key": "action",
+                                            "value": "{{framework_action_get_items}}",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "key": "limit",
+                                            "value": "5",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "key": "offset",
+                                            "value": "0",
+                                            "type": "text"
+                                        }
+                                    ]
+                                },
+                                "url": {
+                                    "raw": "{{sg_endpoint_api}}/getCategories",
+                                    "host": [
+                                        "{{sg_endpoint_api}}"
+                                    ],
+                                    "path": [
+                                        "getCategories"
+                                    ]
+                                }
+                            },
+                            "response": []
+                        },
+                        {
+                            "name": "SG: enable cat export",
+                            "event": [
+                                {
+                                    "listen": "test",
+                                    "script": {
+                                        "exec": [
+                                            "pm.test(\"Status code is 200\", function () {",
+                                            "    pm.response.to.have.status(200);",
+                                            "});",
+                                            "",
+                                            "pm.test(\"enable inactive product export\", function () {",
+                                            "    var jsonData = pm.response.json();",
+                                            "    pm.expect(jsonData.shopgate_settings).lengthOf(1);",
+                                            "    pm.expect(jsonData.shopgate_settings[0].old).to.eq(\"1\");",
+                                            "    pm.expect(jsonData.shopgate_settings[0].new).to.eq(\"0\");",
+                                            "});"
+                                        ],
+                                        "type": "text/javascript"
+                                    }
+                                }
+                            ],
+                            "request": {
+                                "method": "POST",
+                                "header": [
+                                    {
+                                        "key": "X-Shopgate-Auth-User",
+                                        "value": "{{gen_sg_header_auth_user}}"
+                                    },
+                                    {
+                                        "key": "X-Shopgate-Auth-Token",
+                                        "value": "{{gen_sg_header_auth_token}}"
+                                    }
+                                ],
+                                "body": {
+                                    "mode": "formdata",
+                                    "formdata": [
+                                        {
+                                            "key": "shop_number",
+                                            "value": "{{sg_shop_number}}",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "key": "action",
+                                            "value": "{{framework_action_set_settings}}",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "key": "shopgate_settings[0][name]",
+                                            "value": "skip_category_assignment",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "key": "shopgate_settings[0][value]",
+                                            "value": "0",
+                                            "type": "text"
+                                        }
+                                    ]
+                                },
+                                "url": {
+                                    "raw": "{{sg_endpoint_api}}/setSettings",
+                                    "host": [
+                                        "{{sg_endpoint_api}}"
+                                    ],
+                                    "path": [
+                                        "setSettings"
+                                    ]
+                                }
+                            },
+                            "response": []
+                        },
+                        {
+                            "name": "SG: is normal export",
+                            "event": [
+                                {
+                                    "listen": "test",
+                                    "script": {
+                                        "exec": [
+                                            "pm.test(\"Status code is 200\", function () {",
+                                            "    pm.response.to.have.status(200);",
+                                            "});",
+                                            "",
+                                            "pm.test(\"Not an error\", function () {",
+                                            "    pm.response.to.not.have.jsonBody('error');",
+                                            "});",
+                                            "",
+                                            "var jsonObject = xml2Json(responseBody);",
+                                            "pm.test(\"Check products have categories exported\", function () {",
+                                            "    console.log(jsonObject)",
+                                            "    jsonObject.items.item.forEach(item => {",
+                                            "        pm.expect(item.categories.category).to.not.be.undefined;",
+                                            "    });",
+                                            "});"
+                                        ],
+                                        "type": "text/javascript"
+                                    }
+                                }
+                            ],
+                            "request": {
+                                "method": "POST",
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "*/*"
+                                    },
+                                    {
+                                        "key": "X-Shopgate-Auth-User",
+                                        "value": "{{gen_sg_header_auth_user}}"
+                                    },
+                                    {
+                                        "key": "X-Shopgate-Auth-Token",
+                                        "value": "{{gen_sg_header_auth_token}}"
+                                    }
+                                ],
+                                "body": {
+                                    "mode": "formdata",
+                                    "formdata": [
+                                        {
+                                            "key": "shop_number",
+                                            "value": "{{sg_shop_number}}",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "key": "action",
+                                            "value": "{{framework_action_get_items}}",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "key": "limit",
+                                            "value": "5",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "key": "offset",
+                                            "value": "0",
+                                            "type": "text"
+                                        }
+                                    ]
+                                },
+                                "url": {
+                                    "raw": "{{sg_endpoint_api}}/getItems",
+                                    "host": [
+                                        "{{sg_endpoint_api}}"
+                                    ],
+                                    "path": [
+                                        "getItems"
+                                    ]
+                                }
+                            },
+                            "response": []
+                        }
+                    ],
+                    "description": "For merchants with expensive exports we allow to export products without categories. This should increase performance. Internal ref. SG-184."
                 },
                 {
-                  "key": "shopgate_settings[0][name]",
-                  "value": "export_product_inactive",
-                  "type": "text"
-                },
-                {
-                  "key": "shopgate_settings[0][value]",
-                  "value": "1",
-                  "type": "text"
+                    "name": "Check Prices (grps)",
+                    "item": [
+                        {
+                            "name": "SG: disable adv price export",
+                            "event": [
+                                {
+                                    "listen": "test",
+                                    "script": {
+                                        "exec": [
+                                            "pm.test(\"Status code is 200\", function () {",
+                                            "    pm.response.to.have.status(200);",
+                                            "});",
+                                            "",
+                                            "pm.test(\"enable setting\", function () {",
+                                            "    var jsonData = pm.response.json();",
+                                            "    pm.expect(jsonData.shopgate_settings).lengthOf(1);",
+                                            "    pm.expect(jsonData.shopgate_settings[0].old).to.eq(\"0\");",
+                                            "    pm.expect(jsonData.shopgate_settings[0].new).to.eq(\"1\");",
+                                            "});"
+                                        ],
+                                        "type": "text/javascript"
+                                    }
+                                }
+                            ],
+                            "request": {
+                                "method": "POST",
+                                "header": [
+                                    {
+                                        "key": "X-Shopgate-Auth-User",
+                                        "value": "{{gen_sg_header_auth_user}}"
+                                    },
+                                    {
+                                        "key": "X-Shopgate-Auth-Token",
+                                        "value": "{{gen_sg_header_auth_token}}"
+                                    }
+                                ],
+                                "body": {
+                                    "mode": "formdata",
+                                    "formdata": [
+                                        {
+                                            "key": "shop_number",
+                                            "value": "{{sg_shop_number}}",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "key": "action",
+                                            "value": "{{framework_action_set_settings}}",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "key": "shopgate_settings[0][name]",
+                                            "value": "skip_advanced_price_export",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "key": "shopgate_settings[0][value]",
+                                            "value": "1",
+                                            "type": "text"
+                                        }
+                                    ]
+                                },
+                                "url": {
+                                    "raw": "{{sg_endpoint_api}}/setSettings",
+                                    "host": [
+                                        "{{sg_endpoint_api}}"
+                                    ],
+                                    "path": [
+                                        "setSettings"
+                                    ]
+                                }
+                            },
+                            "response": []
+                        },
+                        {
+                            "name": "SG: check no price export",
+                            "event": [
+                                {
+                                    "listen": "test",
+                                    "script": {
+                                        "exec": [
+                                            "pm.test(\"Status code is 200\", function () {",
+                                            "    pm.response.to.have.status(200);",
+                                            "});",
+                                            "",
+                                            "pm.test(\"Not an error\", function () {",
+                                            "    pm.response.to.not.have.jsonBody('error');",
+                                            "});",
+                                            "",
+                                            "var jsonObject = xml2Json(responseBody);",
+                                            "pm.test(\"Check products have categories exported\", () => {",
+                                            "    pm.expect(jsonObject.items.item.prices).to.not.be.undefined;",
+                                            "    const price = jsonObject.items.item.prices;",
+                                            "    pm.expect(price.price).to.eq('500');",
+                                            "    pm.expect(price.sale_price).to.eq('400');",
+                                            "    pm.expect(price.base_price).to.contain('200');",
+                                            "    pm.expect(price.price).to.eq('500');",
+                                            "});",
+                                            "",
+                                            "pm.test(\"Check tier prices\", () => {",
+                                            "    pm.expect(jsonObject.items.item.prices.tier_prices).to.be.undefined;",
+                                            "});",
+                                            "",
+                                            "function checkGrp(tier, discount, min, type, customerGrpId) {",
+                                            "    pm.expect(tier._, 'incorrect discount').to.eq(discount);",
+                                            "    pm.expect(tier.$.threshold, 'incorrect threshold').to.eq(min);",
+                                            "    pm.expect(tier.$.type, 'icnorrect type').to.eq(type);",
+                                            "    if (customerGrpId) {",
+                                            "        pm.expect(tier.$.customer_group_uid, 'incorrect customer grp').to.eq(customerGrpId);",
+                                            "    }",
+                                            "}",
+                                            "function checkFixedDiscount(tier, discount, min, type, max) {",
+                                            "    checkGrp(tier, discount, min, type, null);",
+                                            "    pm.expect(tier.$.max_quantity, 'incorrect max').to.eq(max);",
+                                            "}"
+                                        ],
+                                        "type": "text/javascript"
+                                    }
+                                }
+                            ],
+                            "request": {
+                                "method": "POST",
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "*/*"
+                                    },
+                                    {
+                                        "key": "X-Shopgate-Auth-User",
+                                        "value": "{{gen_sg_header_auth_user}}"
+                                    },
+                                    {
+                                        "key": "X-Shopgate-Auth-Token",
+                                        "value": "{{gen_sg_header_auth_token}}"
+                                    }
+                                ],
+                                "body": {
+                                    "mode": "formdata",
+                                    "formdata": [
+                                        {
+                                            "key": "shop_number",
+                                            "value": "{{sg_shop_number}}",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "key": "action",
+                                            "value": "{{framework_action_get_items}}",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "key": "limit",
+                                            "value": "5",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "key": "offset",
+                                            "value": "0",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "key": "uids[]",
+                                            "value": "{{created_product2_id}}",
+                                            "type": "text"
+                                        }
+                                    ]
+                                },
+                                "url": {
+                                    "raw": "{{sg_endpoint_api}}/getItems",
+                                    "host": [
+                                        "{{sg_endpoint_api}}"
+                                    ],
+                                    "path": [
+                                        "getItems"
+                                    ]
+                                }
+                            },
+                            "response": []
+                        },
+                        {
+                            "name": "SG: enable adv price export",
+                            "event": [
+                                {
+                                    "listen": "test",
+                                    "script": {
+                                        "exec": [
+                                            "pm.test(\"Status code is 200\", function () {",
+                                            "    pm.response.to.have.status(200);",
+                                            "});",
+                                            "",
+                                            "pm.test(\"disable setting\", function () {",
+                                            "    var jsonData = pm.response.json();",
+                                            "    pm.expect(jsonData.shopgate_settings).lengthOf(1);",
+                                            "    pm.expect(jsonData.shopgate_settings[0].old).to.eq(\"1\");",
+                                            "    pm.expect(jsonData.shopgate_settings[0].new).to.eq(\"0\");",
+                                            "});"
+                                        ],
+                                        "type": "text/javascript"
+                                    }
+                                }
+                            ],
+                            "request": {
+                                "method": "POST",
+                                "header": [
+                                    {
+                                        "key": "X-Shopgate-Auth-User",
+                                        "value": "{{gen_sg_header_auth_user}}"
+                                    },
+                                    {
+                                        "key": "X-Shopgate-Auth-Token",
+                                        "value": "{{gen_sg_header_auth_token}}"
+                                    }
+                                ],
+                                "body": {
+                                    "mode": "formdata",
+                                    "formdata": [
+                                        {
+                                            "key": "shop_number",
+                                            "value": "{{sg_shop_number}}",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "key": "action",
+                                            "value": "{{framework_action_set_settings}}",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "key": "shopgate_settings[0][name]",
+                                            "value": "skip_advanced_price_export",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "key": "shopgate_settings[0][value]",
+                                            "value": "0",
+                                            "type": "text"
+                                        }
+                                    ]
+                                },
+                                "url": {
+                                    "raw": "{{sg_endpoint_api}}/setSettings",
+                                    "host": [
+                                        "{{sg_endpoint_api}}"
+                                    ],
+                                    "path": [
+                                        "setSettings"
+                                    ]
+                                }
+                            },
+                            "response": []
+                        },
+                        {
+                            "name": "SG: check prices",
+                            "event": [
+                                {
+                                    "listen": "test",
+                                    "script": {
+                                        "exec": [
+                                            "pm.test(\"Status code is 200\", function () {",
+                                            "    pm.response.to.have.status(200);",
+                                            "});",
+                                            "",
+                                            "pm.test(\"Not an error\", function () {",
+                                            "    pm.response.to.not.have.jsonBody('error');",
+                                            "});",
+                                            "",
+                                            "var jsonObject = xml2Json(responseBody);",
+                                            "pm.test(\"Check products have categories exported\", () => {",
+                                            "    pm.expect(jsonObject.items.item.prices).to.not.be.undefined;",
+                                            "    const price = jsonObject.items.item.prices;",
+                                            "    pm.expect(price.price).to.eq('500');",
+                                            "    pm.expect(price.sale_price).to.eq('400');",
+                                            "    pm.expect(price.base_price).to.contain('200');",
+                                            "    pm.expect(price.price).to.eq('500');",
+                                            "});",
+                                            "",
+                                            "pm.test(\"Check tier prices\", () => {",
+                                            "    pm.expect(jsonObject.items.item.prices.tier_prices.tier_price).to.not.be.undefined;",
+                                            "    const tiers = jsonObject.items.item.prices.tier_prices.tier_price;",
+                                            "    checkGrp(tiers[0], '10', '5', 'percent', '1');",
+                                            "    checkGrp(tiers[1], '20', '10', 'percent', '1');",
+                                            "    checkGrp(tiers[2], '50', '15', 'percent', '1');",
+                                            "    checkFixedDiscount(tiers[3], '200', '2', 'fixed', '3');",
+                                            "});",
+                                            "",
+                                            "function checkGrp(tier, discount, min, type, customerGrpId) {",
+                                            "    pm.expect(tier._, 'incorrect discount').to.eq(discount);",
+                                            "    pm.expect(tier.$.threshold, 'incorrect threshold').to.eq(min);",
+                                            "    pm.expect(tier.$.type, 'icnorrect type').to.eq(type);",
+                                            "    if (customerGrpId) {",
+                                            "        pm.expect(tier.$.customer_group_uid, 'incorrect customer grp').to.eq(customerGrpId);",
+                                            "    }",
+                                            "}",
+                                            "function checkFixedDiscount(tier, discount, min, type, max) {",
+                                            "    checkGrp(tier, discount, min, type, null);",
+                                            "    pm.expect(tier.$.max_quantity, 'incorrect max').to.eq(max);",
+                                            "}"
+                                        ],
+                                        "type": "text/javascript"
+                                    }
+                                }
+                            ],
+                            "request": {
+                                "method": "POST",
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "*/*"
+                                    },
+                                    {
+                                        "key": "X-Shopgate-Auth-User",
+                                        "value": "{{gen_sg_header_auth_user}}"
+                                    },
+                                    {
+                                        "key": "X-Shopgate-Auth-Token",
+                                        "value": "{{gen_sg_header_auth_token}}"
+                                    }
+                                ],
+                                "body": {
+                                    "mode": "formdata",
+                                    "formdata": [
+                                        {
+                                            "key": "shop_number",
+                                            "value": "{{sg_shop_number}}",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "key": "action",
+                                            "value": "{{framework_action_get_items}}",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "key": "limit",
+                                            "value": "5",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "key": "offset",
+                                            "value": "0",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "key": "uids[]",
+                                            "value": "{{created_product2_id}}",
+                                            "type": "text"
+                                        }
+                                    ]
+                                },
+                                "url": {
+                                    "raw": "{{sg_endpoint_api}}/getItems",
+                                    "host": [
+                                        "{{sg_endpoint_api}}"
+                                    ],
+                                    "path": [
+                                        "getItems"
+                                    ]
+                                }
+                            },
+                            "response": []
+                        }
+                    ]
                 }
-              ]
-            },
-            "url": {
-              "raw": "{{sg_endpoint_api}}/setSettings",
-              "host": [
-                "{{sg_endpoint_api}}"
-              ],
-              "path": [
-                "setSettings"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "SW: config cache clear",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test(\"Status code is 200\", function () {\r",
-                  "    pm.response.to.have.status(200);\r",
-                  "});"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "DELETE",
-            "header": [],
-            "url": {
-              "raw": "{{sw_endpoint_api}}/caches/config",
-              "host": [
-                "{{sw_endpoint_api}}"
-              ],
-              "path": [
-                "caches",
-                "config"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "SG: try inactive export",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test(\"Status code is 200\", function () {",
-                  "    pm.response.to.have.status(200);",
-                  "});",
-                  "",
-                  "pm.test(\"Not an error\", function () {",
-                  "    pm.response.to.not.have.jsonBody('error');",
-                  "});",
-                  "",
-                  "pm.test(\"Check product gets exported now\", function () {",
-                  "    var jsonObject = xml2Json(responseBody);",
-                  "    pm.expect(jsonObject.items.item.$.uid).to.eql(pm.environment.get('created_product1_id').toString());",
-                  "    pm.expect(jsonObject.items.item.stock.is_saleable).to.eq('0');",
-                  "});"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Accept",
-                "value": "*/*"
-              },
-              {
-                "key": "X-Shopgate-Auth-User",
-                "value": "{{gen_sg_header_auth_user}}"
-              },
-              {
-                "key": "X-Shopgate-Auth-Token",
-                "value": "{{gen_sg_header_auth_token}}"
-              }
             ],
-            "body": {
-              "mode": "formdata",
-              "formdata": [
-                {
-                  "key": "shop_number",
-                  "value": "{{sg_shop_number}}",
-                  "type": "text"
-                },
-                {
-                  "key": "action",
-                  "value": "{{framework_action_get_items}}",
-                  "type": "text"
-                },
-                {
-                  "key": "limit",
-                  "value": "5",
-                  "type": "text"
-                },
-                {
-                  "key": "offset",
-                  "value": "0",
-                  "type": "text"
-                },
-                {
-                  "key": "uids[]",
-                  "value": "{{created_product1_id}}",
-                  "type": "text"
-                }
-              ]
-            },
-            "url": {
-              "raw": "{{sg_endpoint_api}}/getItems",
-              "host": [
-                "{{sg_endpoint_api}}"
-              ],
-              "path": [
-                "getItems"
-              ]
-            }
-          },
-          "response": []
+            "description": "Catalog export related tests"
         },
         {
-          "name": "SG: unset export inactive",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test(\"Status code is 200\", function () {",
-                  "    pm.response.to.have.status(200);",
-                  "});",
-                  "",
-                  "pm.test(\"disable inactive product export\", function () {",
-                  "    var jsonData = pm.response.json();",
-                  "    pm.expect(jsonData.shopgate_settings).lengthOf(1);",
-                  "    pm.expect(jsonData.shopgate_settings[0].new).to.eq(\"0\");",
-                  "});"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "X-Shopgate-Auth-User",
-                "value": "{{gen_sg_header_auth_user}}"
-              },
-              {
-                "key": "X-Shopgate-Auth-Token",
-                "value": "{{gen_sg_header_auth_token}}"
-              }
+            "name": "Deactivate shop test",
+            "item": [
+                {
+                    "name": "SG: try deactivate store",
+                    "event": [
+                        {
+                            "listen": "test",
+                            "script": {
+                                "exec": [
+                                    "pm.test(\"Status code is 200\", function () {",
+                                    "    pm.response.to.have.status(200);",
+                                    "});",
+                                    "",
+                                    "pm.test(\"de-activation via plugin is not implemented\", function () {",
+                                    "    var jsonData = pm.response.json();",
+                                    "    pm.expect(jsonData.shopgate_settings).lengthOf(1);",
+                                    "    pm.expect(jsonData.shopgate_settings[0].old).to.eq(false);",
+                                    "});"
+                                ],
+                                "type": "text/javascript"
+                            }
+                        }
+                    ],
+                    "request": {
+                        "method": "POST",
+                        "header": [
+                            {
+                                "key": "X-Shopgate-Auth-User",
+                                "value": "{{gen_sg_header_auth_user}}"
+                            },
+                            {
+                                "key": "X-Shopgate-Auth-Token",
+                                "value": "{{gen_sg_header_auth_token}}"
+                            }
+                        ],
+                        "body": {
+                            "mode": "formdata",
+                            "formdata": [
+                                {
+                                    "key": "shop_number",
+                                    "value": "{{sg_shop_number}}",
+                                    "type": "text"
+                                },
+                                {
+                                    "key": "action",
+                                    "value": "{{framework_action_set_settings}}",
+                                    "type": "text"
+                                },
+                                {
+                                    "key": "shopgate_settings[0][name]",
+                                    "value": "shop_is_active",
+                                    "type": "text"
+                                },
+                                {
+                                    "key": "shopgate_settings[0][value]",
+                                    "value": "0",
+                                    "type": "text"
+                                }
+                            ]
+                        },
+                        "url": {
+                            "raw": "{{sg_endpoint_api}}/setSettings",
+                            "host": [
+                                "{{sg_endpoint_api}}"
+                            ],
+                            "path": [
+                                "setSettings"
+                            ]
+                        }
+                    },
+                    "response": []
+                },
+                {
+                    "name": "SW: config cache clear",
+                    "event": [
+                        {
+                            "listen": "test",
+                            "script": {
+                                "exec": [
+                                    "pm.test(\"Status code is 200\", function () {\r",
+                                    "    pm.response.to.have.status(200);\r",
+                                    "});"
+                                ],
+                                "type": "text/javascript"
+                            }
+                        }
+                    ],
+                    "request": {
+                        "method": "DELETE",
+                        "header": [],
+                        "url": {
+                            "raw": "{{sw_endpoint_api}}/caches/config",
+                            "host": [
+                                "{{sw_endpoint_api}}"
+                            ],
+                            "path": [
+                                "caches",
+                                "config"
+                            ]
+                        }
+                    },
+                    "response": []
+                },
+                {
+                    "name": "SG: ping",
+                    "event": [
+                        {
+                            "listen": "test",
+                            "script": {
+                                "exec": [
+                                    "pm.test(\"Status code is 200\", function () {",
+                                    "    pm.response.to.have.status(200);",
+                                    "});",
+                                    "",
+                                    "pm.test(\"Ping works\", function () {",
+                                    "    var jsonData = pm.response.json();",
+                                    "    pm.expect(jsonData.pong).to.eq('OK');",
+                                    "});"
+                                ],
+                                "type": "text/javascript"
+                            }
+                        }
+                    ],
+                    "request": {
+                        "method": "POST",
+                        "header": [
+                            {
+                                "key": "X-Shopgate-Auth-User",
+                                "value": "{{gen_sg_header_auth_user}}"
+                            },
+                            {
+                                "key": "X-Shopgate-Auth-Token",
+                                "value": "{{gen_sg_header_auth_token}}"
+                            }
+                        ],
+                        "body": {
+                            "mode": "formdata",
+                            "formdata": [
+                                {
+                                    "key": "shop_number",
+                                    "value": "{{sg_shop_number}}",
+                                    "type": "text"
+                                },
+                                {
+                                    "key": "action",
+                                    "value": "{{framework_action_set_settings}}",
+                                    "type": "text"
+                                },
+                                {
+                                    "key": "shopgate_settings[0][name]",
+                                    "value": "shop_is_active",
+                                    "type": "text"
+                                },
+                                {
+                                    "key": "shopgate_settings[0][value]",
+                                    "value": "0",
+                                    "type": "text"
+                                }
+                            ]
+                        },
+                        "url": {
+                            "raw": "{{sg_endpoint_api}}/ping",
+                            "host": [
+                                "{{sg_endpoint_api}}"
+                            ],
+                            "path": [
+                                "ping"
+                            ]
+                        }
+                    },
+                    "response": []
+                }
             ],
-            "body": {
-              "mode": "formdata",
-              "formdata": [
-                {
-                  "key": "shop_number",
-                  "value": "{{sg_shop_number}}",
-                  "type": "text"
-                },
-                {
-                  "key": "action",
-                  "value": "{{framework_action_set_settings}}",
-                  "type": "text"
-                },
-                {
-                  "key": "shopgate_settings[0][name]",
-                  "value": "export_product_inactive",
-                  "type": "text"
-                },
-                {
-                  "key": "shopgate_settings[0][value]",
-                  "value": "0",
-                  "type": "text"
-                }
-              ]
-            },
-            "url": {
-              "raw": "{{sg_endpoint_api}}/setSettings",
-              "host": [
-                "{{sg_endpoint_api}}"
-              ],
-              "path": [
-                "setSettings"
-              ]
-            }
-          },
-          "response": []
+            "description": "SG runs a deactivation script after every import, so we need to make sure the store does not get deactivated by it\n\n```\n[shopgate_settings] => Array\n       (\n            [0] => Array\n                (\n                    [name] => shop_is_active\n                    [value] => 0\n                )\n\n        )\n\n\n```\n\nStartFragment"
         },
         {
-          "name": "SW: config cache clear",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test(\"Status code is 200\", function () {\r",
-                  "    pm.response.to.have.status(200);\r",
-                  "});"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "DELETE",
-            "header": [],
-            "url": {
-              "raw": "{{sw_endpoint_api}}/caches/config",
-              "host": [
-                "{{sw_endpoint_api}}"
-              ],
-              "path": [
-                "caches",
-                "config"
-              ]
-            }
-          },
-          "response": []
+            "name": "Cleanup",
+            "item": [
+                {
+                    "name": "SW: remove prod 1",
+                    "event": [
+                        {
+                            "listen": "test",
+                            "script": {
+                                "exec": [
+                                    "pm.test(\"Status code is 200\", function () {\r",
+                                    "    pm.response.to.have.status(200);\r",
+                                    "});\r",
+                                    "\r",
+                                    "pm.test(\"Check success\", function () {\r",
+                                    "    var jsonData = pm.response.json();\r",
+                                    "    pm.expect(jsonData.success).to.eq(true);\r",
+                                    "});"
+                                ],
+                                "type": "text/javascript"
+                            }
+                        }
+                    ],
+                    "request": {
+                        "method": "DELETE",
+                        "header": [],
+                        "url": {
+                            "raw": "{{sw_endpoint_api}}/articles/:articleId",
+                            "host": [
+                                "{{sw_endpoint_api}}"
+                            ],
+                            "path": [
+                                "articles",
+                                ":articleId"
+                            ],
+                            "variable": [
+                                {
+                                    "key": "articleId",
+                                    "value": "{{created_product1_id}}"
+                                }
+                            ]
+                        }
+                    },
+                    "response": []
+                },
+                {
+                    "name": "SW: remove prod 2",
+                    "event": [
+                        {
+                            "listen": "test",
+                            "script": {
+                                "exec": [
+                                    "pm.test(\"Status code is 200\", function () {\r",
+                                    "    pm.response.to.have.status(200);\r",
+                                    "});\r",
+                                    "\r",
+                                    "pm.test(\"Check success\", function () {\r",
+                                    "    var jsonData = pm.response.json();\r",
+                                    "    pm.expect(jsonData.success).to.eq(true);\r",
+                                    "});"
+                                ],
+                                "type": "text/javascript"
+                            }
+                        }
+                    ],
+                    "request": {
+                        "method": "DELETE",
+                        "header": [],
+                        "url": {
+                            "raw": "{{sw_endpoint_api}}/articles/:articleId",
+                            "host": [
+                                "{{sw_endpoint_api}}"
+                            ],
+                            "path": [
+                                "articles",
+                                ":articleId"
+                            ],
+                            "variable": [
+                                {
+                                    "key": "articleId",
+                                    "value": "{{created_product2_id}}"
+                                }
+                            ]
+                        }
+                    },
+                    "response": []
+                }
+            ]
+        },
+        {
+            "name": "WebCheckout",
+            "item": [
+                {
+                    "name": "SW: Get customer 1",
+                    "event": [
+                        {
+                            "listen": "prerequest",
+                            "script": {
+                                "exec": [
+                                    "// allowCookie=1\r",
+                                    "const jar = pm.cookies.jar();\r",
+                                    "jar.set(pm.environment.get(\"host\"), 'allowCookie', '1');"
+                                ],
+                                "type": "text/javascript"
+                            }
+                        },
+                        {
+                            "listen": "test",
+                            "script": {
+                                "exec": [
+                                    "pm.test(\"Status code is 200\", function () {",
+                                    "    pm.response.to.have.status(200);",
+                                    "});",
+                                    "",
+                                    "pm.test(\"Your test name\", function () {",
+                                    "    var jsonData = pm.response.json();",
+                                    "    pm.expect(jsonData.data).to.not.be.undefined;",
+                                    "    pm.expect(jsonData.data.number).to.not.be.undefined;",
+                                    "    pm.environment.set('gen_customer_1_num', jsonData.data.number);",
+                                    "});"
+                                ],
+                                "type": "text/javascript"
+                            }
+                        }
+                    ],
+                    "request": {
+                        "method": "GET",
+                        "header": [],
+                        "url": {
+                            "raw": "{{sw_endpoint_api}}/customers/1",
+                            "host": [
+                                "{{sw_endpoint_api}}"
+                            ],
+                            "path": [
+                                "customers",
+                                "1"
+                            ]
+                        }
+                    },
+                    "response": []
+                },
+                {
+                    "name": "SG: login customer",
+                    "event": [
+                        {
+                            "listen": "test",
+                            "script": {
+                                "exec": [
+                                    "// Load the HTML response to $",
+                                    "const $ = cheerio.load(pm.response.text());",
+                                    "pm.test(\"Check that customer got logged in\", function () {",
+                                    "    const greeting = $('.account--display-greeting');",
+                                    "    pm.expect(greeting).to.be.not.undefined;",
+                                    "    pm.expect(greeting.text()).to.contain('Max');",
+                                    "});",
+                                    "",
+                                    "// Allow cookie deletion by going to cookies -> Domain Allowlist",
+                                    "const jar = pm.cookies.jar();",
+                                    "jar.unset(pm.environment.get(\"host\"), 'session-1', (error) => error && console.log(error.message));",
+                                    "jar.unset(pm.environment.get(\"host\"), 'slt', (error) => error && console.log(error.message));"
+                                ],
+                                "type": "text/javascript"
+                            }
+                        }
+                    ],
+                    "request": {
+                        "auth": {
+                            "type": "jwt",
+                            "jwt": [
+                                {
+                                    "key": "payload",
+                                    "value": "{\"customer_id\": \"{{gen_customer_1_num}}\"}",
+                                    "type": "string"
+                                },
+                                {
+                                    "key": "addTokenTo",
+                                    "value": "queryParam",
+                                    "type": "string"
+                                },
+                                {
+                                    "key": "secret",
+                                    "value": "{{sg_api_key}}",
+                                    "type": "string"
+                                },
+                                {
+                                    "key": "isSecretBase64Encoded",
+                                    "value": false,
+                                    "type": "boolean"
+                                },
+                                {
+                                    "key": "algorithm",
+                                    "value": "HS256",
+                                    "type": "string"
+                                },
+                                {
+                                    "key": "headerPrefix",
+                                    "value": "Bearer",
+                                    "type": "string"
+                                },
+                                {
+                                    "key": "queryParamKey",
+                                    "value": "token",
+                                    "type": "string"
+                                },
+                                {
+                                    "key": "header",
+                                    "value": "{}",
+                                    "type": "string"
+                                }
+                            ]
+                        },
+                        "method": "GET",
+                        "header": [],
+                        "url": {
+                            "raw": "{{sg_endpoint_api}}/login",
+                            "host": [
+                                "{{sg_endpoint_api}}"
+                            ],
+                            "path": [
+                                "login"
+                            ]
+                        }
+                    },
+                    "response": []
+                },
+                {
+                    "name": "SG: create guest cart",
+                    "event": [
+                        {
+                            "listen": "test",
+                            "script": {
+                                "exec": [
+                                    "pm.test(\"Status code is 201\", function () {",
+                                    "    pm.response.to.have.status(201);",
+                                    "});",
+                                    "",
+                                    "pm.test(\"Get session\", function () {",
+                                    "    var jsonData = pm.response.json();",
+                                    "    pm.expect(jsonData.sessionId).to.not.be.undefined;",
+                                    "    pm.environment.set('gen_sessionId_guest', jsonData.sessionId);",
+                                    "});",
+                                    "",
+                                    "",
+                                    "// Allow cookie deletion by going to cookies -> Domain Allowlist",
+                                    "const jar = pm.cookies.jar();",
+                                    "jar.unset(pm.environment.get(\"host\"), 'session-1', (error) => error && console.log(error.message));",
+                                    "jar.unset(pm.environment.get(\"host\"), 'slt', (error) => error && console.log(error.message));"
+                                ],
+                                "type": "text/javascript"
+                            }
+                        }
+                    ],
+                    "request": {
+                        "method": "POST",
+                        "header": [
+                            {
+                                "key": "User-Agent",
+                                "value": "Shopgate PWA",
+                                "type": "text"
+                            }
+                        ],
+                        "body": {
+                            "mode": "raw",
+                            "raw": "{\n    \"articles\": [\n        {\n            \"product_id\": \"{{gen_product_main_id}}\",\n            \"variant_id\": \"\",\n            \"quantity\": 1,\n            \"options\": []\n        }\n    ],\n    \"customerId\": null\n}",
+                            "options": {
+                                "raw": {
+                                    "language": "json"
+                                }
+                            }
+                        },
+                        "url": {
+                            "raw": "{{sg_endpoint_api}}/addToCart",
+                            "host": [
+                                "{{sg_endpoint_api}}"
+                            ],
+                            "path": [
+                                "addToCart"
+                            ]
+                        }
+                    },
+                    "response": []
+                },
+                {
+                    "name": "SG: login guest",
+                    "event": [
+                        {
+                            "listen": "test",
+                            "script": {
+                                "exec": [
+                                    "// Load the HTML response to $",
+                                    "const $ = cheerio.load(pm.response.text());",
+                                    "pm.test(\"Check that customer got logged in\", function () {",
+                                    "    const productInCart = $('.content--sku.content');",
+                                    "    pm.expect(productInCart).to.be.not.undefined;",
+                                    "    pm.expect(productInCart.text()).to.contain('SW10001');",
+                                    "});",
+                                    "",
+                                    "// Allow cookie deletion by going to cookies -> Domain Allowlist",
+                                    "const jar = pm.cookies.jar();",
+                                    "jar.unset(pm.environment.get(\"host\"), 'session-1', (error) => error && console.log(error.message));",
+                                    "jar.unset(pm.environment.get(\"host\"), 'slt', (error) => error && console.log(error.message));"
+                                ],
+                                "type": "text/javascript"
+                            }
+                        }
+                    ],
+                    "request": {
+                        "method": "GET",
+                        "header": [],
+                        "url": {
+                            "raw": "{{sg_endpoint_api}}/login?sessionId={{gen_sessionId_guest}}&guest=1&redirectTo=checkout.cart",
+                            "host": [
+                                "{{sg_endpoint_api}}"
+                            ],
+                            "path": [
+                                "login"
+                            ],
+                            "query": [
+                                {
+                                    "key": "sessionId",
+                                    "value": "{{gen_sessionId_guest}}"
+                                },
+                                {
+                                    "key": "guest",
+                                    "value": "1"
+                                },
+                                {
+                                    "key": "redirectTo",
+                                    "value": "checkout.cart"
+                                }
+                            ]
+                        }
+                    },
+                    "response": []
+                }
+            ]
         }
-      ],
-      "description": "SG-145 feature request. Exporting inactive products configuration."
+    ],
+    "auth": {
+        "type": "basic",
+        "basic": [
+            {
+                "key": "password",
+                "value": "{{sw_api_key}}",
+                "type": "string"
+            },
+            {
+                "key": "username",
+                "value": "demo",
+                "type": "string"
+            }
+        ]
     },
-    {
-      "name": "Deactivate shop test",
-      "item": [
+    "event": [
         {
-          "name": "SG: try deactivate store",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
+            "listen": "prerequest",
+            "script": {
+                "type": "text/javascript",
                 "exec": [
-                  "pm.test(\"Status code is 200\", function () {",
-                  "    pm.response.to.have.status(200);",
-                  "});",
-                  "",
-                  "pm.test(\"de-activation via plugin is not implemented\", function () {",
-                  "    var jsonData = pm.response.json();",
-                  "    pm.expect(jsonData.shopgate_settings).lengthOf(1);",
-                  "    pm.expect(jsonData.shopgate_settings[0].old).to.eq(false);",
-                  "});"
-                ],
-                "type": "text/javascript"
-              }
+                    "/**",
+                    " *  SG Token generation",
+                    " */",
+                    "var tstamp = Math.floor(Date.now() / 1000);",
+                    "",
+                    "// Use the CryptoJS",
+                    "var authUser = pm.environment.get('sg_customer_number') + \"-\" + tstamp;",
+                    "var tokenData = \"SPA-\" + pm.environment.get('sg_customer_number') + \"-\" + tstamp + \"-\" + pm.environment.get('sg_api_key');",
+                    "",
+                    "var authToken = CryptoJS.SHA1(tokenData).toString();",
+                    "",
+                    "// Set the new header values",
+                    "pm.environment.set(\"gen_sg_header_auth_user\", authUser);",
+                    "pm.environment.set(\"gen_sg_header_auth_token\", authToken);"
+                ]
             }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "X-Shopgate-Auth-User",
-                "value": "{{gen_sg_header_auth_user}}"
-              },
-              {
-                "key": "X-Shopgate-Auth-Token",
-                "value": "{{gen_sg_header_auth_token}}"
-              }
-            ],
-            "body": {
-              "mode": "formdata",
-              "formdata": [
-                {
-                  "key": "shop_number",
-                  "value": "{{sg_shop_number}}",
-                  "type": "text"
-                },
-                {
-                  "key": "action",
-                  "value": "{{framework_action_set_settings}}",
-                  "type": "text"
-                },
-                {
-                  "key": "shopgate_settings[0][name]",
-                  "value": "shop_is_active",
-                  "type": "text"
-                },
-                {
-                  "key": "shopgate_settings[0][value]",
-                  "value": "0",
-                  "type": "text"
-                }
-              ]
-            },
-            "url": {
-              "raw": "{{sg_endpoint_api}}/setSettings",
-              "host": [
-                "{{sg_endpoint_api}}"
-              ],
-              "path": [
-                "setSettings"
-              ]
-            }
-          },
-          "response": []
         },
         {
-          "name": "SW: config cache clear",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
+            "listen": "test",
+            "script": {
+                "type": "text/javascript",
                 "exec": [
-                  "pm.test(\"Status code is 200\", function () {\r",
-                  "    pm.response.to.have.status(200);\r",
-                  "});"
-                ],
-                "type": "text/javascript"
-              }
+                    ""
+                ]
             }
-          ],
-          "request": {
-            "method": "DELETE",
-            "header": [],
-            "url": {
-              "raw": "{{sw_endpoint_api}}/caches/config",
-              "host": [
-                "{{sw_endpoint_api}}"
-              ],
-              "path": [
-                "caches",
-                "config"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "SG: ping",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test(\"Status code is 200\", function () {",
-                  "    pm.response.to.have.status(200);",
-                  "});",
-                  "",
-                  "pm.test(\"Ping works\", function () {",
-                  "    var jsonData = pm.response.json();",
-                  "    pm.expect(jsonData.pong).to.eq('OK');",
-                  "});"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "X-Shopgate-Auth-User",
-                "value": "{{gen_sg_header_auth_user}}"
-              },
-              {
-                "key": "X-Shopgate-Auth-Token",
-                "value": "{{gen_sg_header_auth_token}}"
-              }
-            ],
-            "body": {
-              "mode": "formdata",
-              "formdata": [
-                {
-                  "key": "shop_number",
-                  "value": "{{sg_shop_number}}",
-                  "type": "text"
-                },
-                {
-                  "key": "action",
-                  "value": "{{framework_action_set_settings}}",
-                  "type": "text"
-                },
-                {
-                  "key": "shopgate_settings[0][name]",
-                  "value": "shop_is_active",
-                  "type": "text"
-                },
-                {
-                  "key": "shopgate_settings[0][value]",
-                  "value": "0",
-                  "type": "text"
-                }
-              ]
-            },
-            "url": {
-              "raw": "{{sg_endpoint_api}}/ping",
-              "host": [
-                "{{sg_endpoint_api}}"
-              ],
-              "path": [
-                "ping"
-              ]
-            }
-          },
-          "response": []
         }
-      ],
-      "description": "SG runs a deactivation script after every import, so we need to make sure the store does not get deactivated by it\n\n```\n[shopgate_settings] => Array\n       (\n            [0] => Array\n                (\n                    [name] => shop_is_active\n                    [value] => 0\n                )\n\n        )\n\n\n```\n\nStartFragment"
-    },
-    {
-      "name": "Cleanup",
-      "item": [
-        {
-          "name": "SW: remove prod 1",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test(\"Status code is 200\", function () {\r",
-                  "    pm.response.to.have.status(200);\r",
-                  "});\r",
-                  "\r",
-                  "pm.test(\"Check success\", function () {\r",
-                  "    var jsonData = pm.response.json();\r",
-                  "    pm.expect(jsonData.success).to.eq(true);\r",
-                  "});"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "DELETE",
-            "header": [],
-            "url": {
-              "raw": "{{sw_endpoint_api}}/articles/:articleId",
-              "host": [
-                "{{sw_endpoint_api}}"
-              ],
-              "path": [
-                "articles",
-                ":articleId"
-              ],
-              "variable": [
-                {
-                  "key": "articleId",
-                  "value": "{{created_product1_id}}"
-                }
-              ]
-            }
-          },
-          "response": []
-        }
-      ]
-    }
-  ],
-  "auth": {
-    "type": "basic",
-    "basic": [
-      {
-        "key": "password",
-        "value": "{{sw_api_key}}",
-        "type": "string"
-      },
-      {
-        "key": "username",
-        "value": "demo",
-        "type": "string"
-      }
     ]
-  },
-  "event": [
-    {
-      "listen": "prerequest",
-      "script": {
-        "type": "text/javascript",
-        "exec": [
-          "/**",
-          " *  SG Token generation",
-          " */",
-          "var tstamp = Math.floor(Date.now() / 1000);",
-          "",
-          "// Use the CryptoJS",
-          "var authUser = pm.environment.get('sg_customer_number') + \"-\" + tstamp;",
-          "var tokenData = \"SPA-\" + pm.environment.get('sg_customer_number') + \"-\" + tstamp + \"-\" + pm.environment.get('sg_api_key');",
-          "",
-          "var authToken = CryptoJS.SHA1(tokenData).toString();",
-          "",
-          "// Set the new header values",
-          "pm.environment.set(\"gen_sg_header_auth_user\", authUser);",
-          "pm.environment.set(\"gen_sg_header_auth_token\", authToken);"
-        ]
-      }
-    },
-    {
-      "listen": "test",
-      "script": {
-        "type": "text/javascript",
-        "exec": [
-          ""
-        ]
-      }
-    }
-  ]
 }

--- a/tests/Postman/collection.json
+++ b/tests/Postman/collection.json
@@ -1643,7 +1643,7 @@
                                     "    pm.response.to.have.status(200);",
                                     "});",
                                     "",
-                                    "pm.test(\"Your test name\", function () {",
+                                    "pm.test(\"get customer data\", function () {",
                                     "    var jsonData = pm.response.json();",
                                     "    pm.expect(jsonData.data).to.not.be.undefined;",
                                     "    pm.expect(jsonData.data.number).to.not.be.undefined;",
@@ -1741,7 +1741,13 @@
                             ]
                         },
                         "method": "GET",
-                        "header": [],
+                        "header": [
+                            {
+                                "key": "User-Agent",
+                                "value": "PostmanRuntime libshopgate",
+                                "type": "text"
+                            }
+                        ],
                         "url": {
                             "raw": "{{sg_endpoint_api}}/login",
                             "host": [
@@ -1820,7 +1826,7 @@
                                 "exec": [
                                     "// Load the HTML response to $",
                                     "const $ = cheerio.load(pm.response.text());",
-                                    "pm.test(\"Check that customer got logged in\", function () {",
+                                    "pm.test(\"Check that guest got logged in\", function () {",
                                     "    const productInCart = $('.content--sku.content');",
                                     "    pm.expect(productInCart).to.be.not.undefined;",
                                     "    pm.expect(productInCart.text()).to.contain('SW10001');",
@@ -1861,6 +1867,103 @@
                                 }
                             ]
                         }
+                    },
+                    "response": []
+                },
+                {
+                    "name": "SG: login & prod page",
+                    "event": [
+                        {
+                            "listen": "test",
+                            "script": {
+                                "exec": [
+                                    "// Load the HTML response to $",
+                                    "const $ = cheerio.load(pm.response.text());",
+                                    "pm.test(\"Check that we have a sessionId being sent to App\", function () {",
+                                    "    const session = $('script:contains(\"sessionId\")');",
+                                    "    pm.expect(session).to.be.not.undefined;",
+                                    "    pm.expect(session.text()).to.contain(\"{'sessionId': '\");",
+                                    "});",
+                                    "",
+                                    "// Allow cookie deletion by going to cookies -> Domain Allowlist",
+                                    "const jar = pm.cookies.jar();",
+                                    "jar.unset(pm.environment.get(\"host\"), 'session-1', (error) => error && console.log(error.message));",
+                                    "jar.unset(pm.environment.get(\"host\"), 'slt', (error) => error && console.log(error.message));"
+                                ],
+                                "type": "text/javascript"
+                            }
+                        }
+                    ],
+                    "request": {
+                        "auth": {
+                            "type": "jwt",
+                            "jwt": [
+                                {
+                                    "key": "payload",
+                                    "value": "{\"customer_id\": \"{{gen_customer_1_num}}\"}",
+                                    "type": "string"
+                                },
+                                {
+                                    "key": "addTokenTo",
+                                    "value": "queryParam",
+                                    "type": "string"
+                                },
+                                {
+                                    "key": "secret",
+                                    "value": "{{sg_api_key}}",
+                                    "type": "string"
+                                },
+                                {
+                                    "key": "isSecretBase64Encoded",
+                                    "value": false,
+                                    "type": "boolean"
+                                },
+                                {
+                                    "key": "algorithm",
+                                    "value": "HS256",
+                                    "type": "string"
+                                },
+                                {
+                                    "key": "headerPrefix",
+                                    "value": "Bearer",
+                                    "type": "string"
+                                },
+                                {
+                                    "key": "queryParamKey",
+                                    "value": "token",
+                                    "type": "string"
+                                },
+                                {
+                                    "key": "header",
+                                    "value": "{}",
+                                    "type": "string"
+                                }
+                            ]
+                        },
+                        "method": "GET",
+                        "header": [
+                            {
+                                "key": "User-Agent",
+                                "value": "PostmanRuntime libshopgate",
+                                "type": "text"
+                            }
+                        ],
+                        "url": {
+                            "raw": "{{sg_endpoint_api}}/login?redirectTo=detail.index.sArticle.3",
+                            "host": [
+                                "{{sg_endpoint_api}}"
+                            ],
+                            "path": [
+                                "login"
+                            ],
+                            "query": [
+                                {
+                                    "key": "redirectTo",
+                                    "value": "detail.index.sArticle.3"
+                                }
+                            ]
+                        },
+                        "description": "Logs in, redirects to product page & checks that the session is being sent to the App."
                     },
                     "response": []
                 }

--- a/tests/Postman/environment.json
+++ b/tests/Postman/environment.json
@@ -1,47 +1,59 @@
 {
-  "id": "87d254fa-02ce-420f-b494-f6321fba37c3",
-  "name": "Shopware 5 (Go)",
-  "values": [
-    {
-      "key": "host",
-      "value": "http://localhost",
-      "enabled": true
-    },
-    {
-      "key": "sw_endpoint_api",
-      "value": "{{host}}{{system_port}}/api",
-      "type": "default",
-      "enabled": true
-    },
-    {
-      "key": "sw_api_key",
-      "value": "",
-      "type": "default",
-      "enabled": true
-    },
-    {
-      "key": "sg_endpoint_api",
-      "value": "{{host}}{{system_port}}/shopgate",
-      "enabled": true
-    },
-    {
-      "key": "sg_api_key",
-      "value": "1111111111111111111",
-      "enabled": true
-    },
-    {
-      "key": "sg_customer_number",
-      "value": "12345",
-      "type": "default",
-      "enabled": true
-    },
-    {
-      "key": "sg_shop_number",
-      "value": "123456",
-      "enabled": true
-    }
-  ],
-  "_postman_variable_scope": "environment",
-  "_postman_exported_at": "2022-11-07T20:00:31.306Z",
-  "_postman_exported_using": "Postman/10.1.1"
+    "id": "de306e91-7dd6-4217-8af4-5114b269e54d",
+    "name": "Shopware 5 (Go)",
+    "values": [
+        {
+            "key": "system_port",
+            "value": "",
+            "type": "default",
+            "enabled": true
+        },
+        {
+            "key": "host",
+            "value": "http://localhost",
+            "enabled": true
+        },
+        {
+            "key": "sw_domain",
+            "value": "{{host}}{{system_port}}",
+            "type": "default",
+            "enabled": true
+        },
+        {
+            "key": "sw_endpoint_api",
+            "value": "{{sw_domain}}/api",
+            "type": "default",
+            "enabled": true
+        },
+        {
+            "key": "sw_api_key",
+            "value": "",
+            "type": "default",
+            "enabled": true
+        },
+        {
+            "key": "sg_endpoint_api",
+            "value": "{{sw_domain}}/shopgate",
+            "enabled": true
+        },
+        {
+            "key": "sg_api_key",
+            "value": "1111111111111111111",
+            "enabled": true
+        },
+        {
+            "key": "sg_customer_number",
+            "value": "12345",
+            "type": "default",
+            "enabled": true
+        },
+        {
+            "key": "sg_shop_number",
+            "value": "123456",
+            "enabled": true
+        }
+    ],
+    "_postman_variable_scope": "environment",
+    "_postman_exported_at": "2023-10-20T20:01:14.105Z",
+    "_postman_exported_using": "Postman/10.19.6"
 }


### PR DESCRIPTION
## Description

Added login route for web checkout. A session can be passed to this route to "log in" a guest. Session manipulation is fairly common in SW5, so presumably no security holes are created here. 

A `user_id` can also be passed to this route, but only via an encrypted token. The route is also able to redirect the logged in user afterwards. 

I used the SW5 php-cs for styling the User.php file.


## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
